### PR TITLE
Add backend Mongo environment defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ dist-ssr
 *.sln
 *.sw?
 .env
+!backend/.env

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ cd backend && npm run db:migrate
 npm run db:seed
 ```
 
+The backend also reads MongoDB connection details from `backend/.env`. By default it points to the local development instance (`mongodb://localhost:27017/workpro4`), but you can safely swap `MONGO_URI` to an Atlas SRV string when using MongoDB Atlas—for example `mongodb+srv://<user>:<pass>@<cluster>.mongodb.net/workpro4?retryWrites=true&w=majority`.
+
 4. **Start development servers:**
 ```bash
 npm run dev

--- a/backend/.env
+++ b/backend/.env
@@ -1,0 +1,5 @@
+PORT=3001
+MONGO_URI=mongodb://localhost:27017/workpro4
+
+# Example Atlas:
+# MONGO_URI=mongodb+srv://<user>:<pass>@<cluster>.mongodb.net/workpro4?retryWrites=true&w=majority


### PR DESCRIPTION
## Summary
- add a committed backend/.env file with default local MongoDB values and an example Atlas SRV connection string
- document in the main README that the backend supports swapping MONGO_URI to a MongoDB Atlas SRV URI

## Testing
- not run (docs and configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68cc1c709a7c832392353fd055830145