### PR TITLE
Add backend tsconfig and adjust vendor contact handling

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx watch src/index.ts",
-    "build": "tsc",
+    "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
     "test": "vitest",
     "db:generate": "prisma generate",

--- a/backend/src/routes/vendors.ts
+++ b/backend/src/routes/vendors.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { z } from 'zod';
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, Prisma } from '@prisma/client';
 import { ok, fail, asyncHandler } from '../utils/response';
 import { authenticateToken, AuthRequest, requireRoles } from '../middleware/auth';
 import { tenantScope } from '../middleware/tenant';
@@ -49,7 +49,7 @@ router.post('/', requireRoles(['planner', 'supervisor', 'admin']), asyncHandler(
   const vendor = await prisma.vendor.create({
     data: {
       name: data.name,
-      contactJson: data.contact || null,
+      contactJson: data.contact ?? Prisma.JsonNull,
       tenantId,
     },
   });
@@ -81,7 +81,9 @@ router.put('/:id', requireRoles(['planner', 'supervisor', 'admin']), asyncHandle
 
   const updateData: any = {};
   if (data.name) updateData.name = data.name;
-  if (data.contact !== undefined) updateData.contactJson = data.contact;
+  if (data.contact !== undefined) {
+    updateData.contactJson = data.contact ?? Prisma.JsonNull;
+  }
 
   const vendor = await prisma.vendor.update({
     where: { id },

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "resolveJsonModule": true
+  },
+  "include": [
+    "src/**/*.ts",
+    "../shared/**/*.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a backend-specific tsconfig with Node-friendly compiler options
- point the backend build script at the new configuration
- adjust vendor route contact persistence to use Prisma.JsonNull under the new checks

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc1c731eec8323ab7f01089aeb81db