### PR TITLE
Add MongoDB connection helper and health endpoints

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -30,7 +30,8 @@
     "helmet": "^7.1.0",
     "express-rate-limit": "^7.1.5",
     "swagger-jsdoc": "^6.2.8",
-    "swagger-ui-express": "^5.0.0"
+    "swagger-ui-express": "^5.0.0",
+    "mongoose": "^8.0.3"
   },
   "devDependencies": {
     "@types/express": "^4.17.17",

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -1,0 +1,13 @@
+import mongoose from 'mongoose';
+
+export async function connectDB(uri: string, dbName?: string) {
+  try {
+    await mongoose.connect(uri, {
+      dbName: dbName ?? process.env.DB_NAME,
+    });
+    console.log('🗄️ Connected to MongoDB');
+  } catch (error) {
+    console.error('❌ Failed to connect to MongoDB');
+    throw error;
+  }
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,9 +1,12 @@
+import 'dotenv/config';
 import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
 import rateLimit from 'express-rate-limit';
+import mongoose from 'mongoose';
 import { requestLogger } from './middleware/requestLogger';
 import { errorHandler } from './middleware/errorHandler';
+import { connectDB } from './db';
 
 // Routes
 import authRoutes from './routes/auth';
@@ -15,7 +18,7 @@ import vendorRoutes from './routes/vendors';
 import searchRoutes from './routes/search';
 
 const app = express();
-const PORT = process.env.PORT || 3001;
+const PORT = Number(process.env.PORT) || 3001;
 
 // Security middleware
 app.use(helmet());
@@ -39,12 +42,12 @@ app.use(express.urlencoded({ extended: true }));
 app.use(requestLogger);
 
 // Health check
-app.get('/health', (req, res) => {
-  res.json({ 
-    status: 'ok', 
-    timestamp: new Date().toISOString(),
-    version: '1.0.0',
-  });
+app.get('/health', (_req, res) => {
+  res.json({ ok: true });
+});
+
+app.get('/health/db', (_req, res) => {
+  res.json({ readyState: mongoose.connection.readyState });
 });
 
 // API routes
@@ -70,8 +73,25 @@ app.use('*', (req, res) => {
   });
 });
 
-app.listen(PORT, () => {
-  console.log(`🚀 Backend server running on port ${PORT}`);
-  console.log(`📊 Health check: http://localhost:${PORT}/health`);
-  console.log(`🔐 API base: http://localhost:${PORT}/api`);
+async function start() {
+  const mongoUri = process.env.MONGO_URI;
+
+  if (!mongoUri) {
+    console.error('❌ MONGO_URI environment variable is required');
+    process.exit(1);
+  }
+
+  await connectDB(mongoUri, process.env.DB_NAME);
+
+  app.listen(PORT, () => {
+    console.log(`🚀 Backend server running on port ${PORT}`);
+    console.log(`🩺 Health check: http://localhost:${PORT}/health`);
+    console.log(`🗄️ DB health: http://localhost:${PORT}/health/db`);
+    console.log(`🔐 API base: http://localhost:${PORT}/api`);
+  });
+}
+
+start().catch((error) => {
+  console.error('❌ Failed to start server', error);
+  process.exit(1);
 });


### PR DESCRIPTION
## Summary
- add a reusable MongoDB connection helper that reports connection success or failure
- update the Express entrypoint to load environment variables, expose `/health` and `/health/db`, and ensure the database is connected before listening
- record the new MongoDB dependency for the backend package

## Testing
- `npm run lint` *(fails: Invalid option '--ext' with eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1c70268883239eb0d4c52f9d2638