### PR TITLE
Remove redundant BrowserRouter wrapper from App

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { queryClient } from './lib/queryClient';
 import { ThemeProvider } from './contexts/ThemeContext';
@@ -21,23 +21,21 @@ export default function App() {
   return (
     <ThemeProvider>
       <QueryClientProvider client={queryClient}>
-        <BrowserRouter>
-          <Routes>
-            <Route path="/login" element={<Login />} />
-            <Route element={<Layout />}>
-              <Route index element={<Dashboard />} />
-              <Route path="assets" element={<Assets />} />
-              <Route path="work-orders" element={<WorkOrders />} />
-              <Route path="pm" element={<PM />} />
-              <Route path="teams" element={<Teams />} />
-              <Route path="inventory" element={<Inventory />} />
-              <Route path="vendors" element={<Vendors />} />
-              <Route path="documents" element={<Documents />} />
-              <Route path="analytics" element={<Analytics />} />
-              <Route path="settings" element={<Settings />} />
-            </Route>
-          </Routes>
-        </BrowserRouter>
+        <Routes>
+          <Route path="/login" element={<Login />} />
+          <Route element={<Layout />}>
+            <Route index element={<Dashboard />} />
+            <Route path="assets" element={<Assets />} />
+            <Route path="work-orders" element={<WorkOrders />} />
+            <Route path="pm" element={<PM />} />
+            <Route path="teams" element={<Teams />} />
+            <Route path="inventory" element={<Inventory />} />
+            <Route path="vendors" element={<Vendors />} />
+            <Route path="documents" element={<Documents />} />
+            <Route path="analytics" element={<Analytics />} />
+            <Route path="settings" element={<Settings />} />
+          </Route>
+        </Routes>
       </QueryClientProvider>
     </ThemeProvider>
   );


### PR DESCRIPTION
## Summary
- remove the BrowserRouter import and wrapper from App so it only renders the route tree
- rely on main.tsx to provide the BrowserRouter context at the top level

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68cd18a5badc8323bfafd80ca6b5bc59