### PR TITLE
Update dev scripts to use root Vite app

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A comprehensive, production-ready CMMS (Computerized Maintenance Management Syst
 
 ### Tech Stack
 - **Backend**: Node.js, Express, TypeScript, Prisma, PostgreSQL, Redis (in `/backend`)
-- **Frontend**: React, TypeScript, TanStack Query, Tailwind CSS, shadcn/ui (in `/frontend`)
+- **Frontend**: React, TypeScript, TanStack Query, Tailwind CSS, shadcn/ui (root `src/`)
 - **Real-time**: Socket.IO for live updates
 - **Queue System**: BullMQ for background jobs
 - **File Storage**: Local development + S3 adapter ready
@@ -36,7 +36,8 @@ A comprehensive, production-ready CMMS (Computerized Maintenance Management Syst
 ```
 workpro-cmms/
 ├── backend/          # Express API server
-├── frontend/         # React web application
+├── src/              # React web application source
+├── frontend/         # Legacy workspace (use root `src/` instead)
 └── docker-compose.yml # Development services
 ```
 
@@ -77,10 +78,10 @@ The backend also reads MongoDB connection details from `backend/.env`. By defaul
 
 4. **Start development servers:**
 ```bash
-npm run dev
+npm run dev:all
 ```
 
-This starts both the backend server (localhost:3001) and frontend app (localhost:3000).
+This starts both the backend server (localhost:3001) and frontend app (localhost:5173). To run only the frontend, use `npm run dev`.
 
 ### Production Build
 ```bash

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,6 @@
+# Legacy Frontend Workspace
+
+This directory contains the previous standalone Vite workspace. The active frontend now lives in the repository root under `src/` and is served by the root-level Vite configuration.
+
+Use the root `npm run dev` script for local development. New UI work should be added to the root `src/` tree instead of this directory.
+

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "dev": "npm run --prefix frontend dev",
+    "dev": "vite",
     "dev:all": "concurrently \"npm run dev\" \"npm run --prefix backend dev\"",
     "build": "vite build",
     "preview": "vite preview --host",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,9 @@
-module.exports = { 
-  plugins: { 
-    tailwindcss: {}, 
-    autoprefixer: {} 
-  } 
+import autoprefixer from 'autoprefixer'
+import tailwindcss from 'tailwindcss'
+
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
 /** @type {import('tailwindcss').Config} */
-module.exports = {
+const config = {
   darkMode: ['class'],
   content: [
     './index.html',
@@ -71,3 +71,5 @@ module.exports = {
   },
   plugins: [],
 }
+
+export default config

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,6 +17,12 @@ export default defineConfig({
   },
   preview: { host: true, port: 4173 },
   optimizeDeps: {
+    entries: ['index.html'],
     exclude: ['lucide-react'],
+  },
+  build: {
+    rollupOptions: {
+      input: 'index.html',
+    },
   },
 })


### PR DESCRIPTION
## Summary
- update the root dev script to invoke Vite against the repository src entry point
- convert build configs to native ESM and ensure Vite only scans the new root app
- refresh documentation and mark the legacy frontend workspace for clarity

## Testing
- npm run dev
- npm run dev:all *(fails: backend dev dependency `tsx` is unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd18a7f374832390d750445e40976c