### PR TITLE
feat: add TypeScript UI primitives

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+type ButtonVariant = 'default' | 'destructive' | 'outline' | 'secondary' | 'ghost' | 'link';
+type ButtonSize = 'default' | 'sm' | 'lg' | 'icon';
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  asChild?: boolean;
+}
+
+const baseClasses =
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50';
+
+const variantClasses: Record<ButtonVariant, string> = {
+  default: 'bg-primary text-primary-foreground shadow hover:bg-primary/90',
+  destructive: 'bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90',
+  outline: 'border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground',
+  secondary: 'bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80',
+  ghost: 'hover:bg-accent hover:text-accent-foreground',
+  link: 'text-primary underline-offset-4 hover:underline'
+};
+
+const sizeClasses: Record<ButtonSize, string> = {
+  default: 'h-9 px-4 py-2',
+  sm: 'h-8 rounded-md px-3 text-xs',
+  lg: 'h-10 rounded-md px-8',
+  icon: 'h-9 w-9'
+};
+
+function getButtonClasses({
+  variant = 'default',
+  size = 'default',
+  className
+}: Pick<ButtonProps, 'variant' | 'size' | 'className'>): string {
+  return cn(baseClasses, variantClasses[variant], sizeClasses[size], className);
+}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = 'default', size = 'default', asChild = false, type = 'button', children, ...props }, ref) => {
+    const computedClassName = getButtonClasses({ variant, size, className });
+
+    if (asChild && React.isValidElement(children)) {
+      return React.cloneElement(children, {
+        className: cn(computedClassName, (children.props as { className?: string }).className),
+        ...props,
+        ref: ref as React.Ref<any>
+      });
+    }
+
+    return (
+      <button type={type} className={computedClassName} ref={ref} {...props}>
+        {children}
+      </button>
+    );
+  }
+);
+
+Button.displayName = 'Button';
+
+export const buttonVariants = getButtonClasses;

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type = 'text', ...props }, ref) => (
+    <input
+      type={type}
+      className={cn(
+        'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  )
+);
+
+Input.displayName = 'Input';

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,136 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+type TabsContextValue = {
+  value?: string;
+  setValue: (next: string) => void;
+};
+
+const TabsContext = React.createContext<TabsContextValue | null>(null);
+
+function useTabsContext(component: string): TabsContextValue {
+  const context = React.useContext(TabsContext);
+  if (!context) {
+    throw new Error(`${component} must be used within <Tabs>`);
+  }
+  return context;
+}
+
+export interface TabsProps extends React.HTMLAttributes<HTMLDivElement> {
+  defaultValue?: string;
+  value?: string;
+  onValueChange?: (value: string) => void;
+}
+
+export const Tabs = React.forwardRef<HTMLDivElement, TabsProps>(
+  ({ defaultValue, value, onValueChange, className, children, ...props }, ref) => {
+    const isControlled = value !== undefined;
+    const [internalValue, setInternalValue] = React.useState<string | undefined>(defaultValue);
+
+    React.useEffect(() => {
+      if (!isControlled) {
+        setInternalValue(defaultValue);
+      }
+    }, [defaultValue, isControlled]);
+
+    const activeValue = isControlled ? value : internalValue;
+
+    const setValue = React.useCallback(
+      (next: string) => {
+        if (!isControlled) {
+          setInternalValue(next);
+        }
+        onValueChange?.(next);
+      },
+      [isControlled, onValueChange]
+    );
+
+    const contextValue = React.useMemo(() => ({ value: activeValue, setValue }), [activeValue, setValue]);
+
+    return (
+      <TabsContext.Provider value={contextValue}>
+        <div ref={ref} className={className} {...props}>
+          {children}
+        </div>
+      </TabsContext.Provider>
+    );
+  }
+);
+
+Tabs.displayName = 'Tabs';
+
+export interface TabsListProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export const TabsList = React.forwardRef<HTMLDivElement, TabsListProps>(
+  ({ className, ...props }, ref) => (
+    <div
+      role="tablist"
+      ref={ref}
+      className={cn('inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground', className)}
+      {...props}
+    />
+  )
+);
+
+TabsList.displayName = 'TabsList';
+
+export interface TabsTriggerProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  value: string;
+}
+
+export const TabsTrigger = React.forwardRef<HTMLButtonElement, TabsTriggerProps>(
+  ({ className, value, onClick, ...props }, ref) => {
+    const { value: activeValue, setValue } = useTabsContext('TabsTrigger');
+    const isActive = activeValue === value;
+
+    return (
+      <button
+        type="button"
+        role="tab"
+        aria-selected={isActive}
+        data-state={isActive ? 'active' : 'inactive'}
+        ref={ref}
+        className={cn(
+          'inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow',
+          className
+        )}
+        onClick={(event) => {
+          setValue(value);
+          onClick?.(event);
+        }}
+        {...props}
+      />
+    );
+  }
+);
+
+TabsTrigger.displayName = 'TabsTrigger';
+
+export interface TabsContentProps extends React.HTMLAttributes<HTMLDivElement> {
+  value: string;
+}
+
+export const TabsContent = React.forwardRef<HTMLDivElement, TabsContentProps>(
+  ({ className, value, ...props }, ref) => {
+    const { value: activeValue } = useTabsContext('TabsContent');
+
+    if (activeValue !== value) {
+      return null;
+    }
+
+    return (
+      <div
+        role="tabpanel"
+        data-state="active"
+        ref={ref}
+        className={cn(
+          'mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+
+TabsContent.displayName = 'TabsContent';


### PR DESCRIPTION
## Summary
- add TypeScript button component with variant, size, and asChild support using the shared cn helper
- provide a forward-ref input component with shadcn styles
- implement tabs primitives backed by a lightweight context to replace the legacy vendor wrapper

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd7b160cb08323bb6f4f6b33f27de8