### PR TITLE
Guard optional navbar initializer

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,11 +9,13 @@ import App from './App';
 
 declare global {
   interface Window {
-    initNavBar: () => void;
+    initNavBar?: () => void;
   }
 }
 
-window.initNavBar();
+if (typeof window.initNavBar === 'function') {
+  window.initNavBar();
+}
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <BrowserRouter>


### PR DESCRIPTION
## Summary
- allow the optional presence of `window.initNavBar`
- guard the initializer invocation so the app no longer errors when it is absent

## Testing
- npm run dev -- --clearScreen false --host

------
https://chatgpt.com/codex/tasks/task_e_68cddc9855b08323aad3a3715e1ec70a