### PR TITLE
Fix auth login state updates

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -43,17 +43,13 @@ export const useAuth = create<AuthState>()(
         try {
           const response = await api.post<LoginResponse>('/auth/login', credentials);
           api.setToken(response.token);
-          set({ 
-            user: response.user, 
-          }
-          )
-          api.setToken(token);
+
           const user = await api.get<User>('/auth/me');
+
           set({ user, isAuthenticated: true, isLoading: false });
         } catch (error) {
           api.clearToken();
-          set({ isLoading: false });
-          set({ user: null, isAuthenticated: false });
+          set({ user: null, isAuthenticated: false, isLoading: false });
         }
       }
     }),


### PR DESCRIPTION
## Summary
- remove duplicate token handling in the auth login flow and rely on the API response token
- fetch the current user after login and update the store in a single state write
- ensure failed logins clear authentication state and loading status consistently

## Testing
- pnpm lint *(fails: Invalid option '--ext' when using eslint.config.js)*
- pnpm exec eslint src/hooks/useAuth.ts *(fails: missing dependency '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68cdf2073ef48323990824493d253773