### PR TITLE
Fix Vite JSX esbuild include

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
   },
   esbuild: {
     loader: 'jsx',
-    include: /src\/.*\.js$/,
+    include: /src\/.*\.[jt]sx?$/,
   },
   server: {
     host: true,
@@ -37,6 +37,7 @@ export default defineConfig({
     esbuildOptions: {
       loader: {
         '.js': 'jsx',
+        '.jsx': 'jsx',
       },
     },
   },


### PR DESCRIPTION
## Summary
- update the esbuild include regex so both .js and .jsx sources are handled
- ensure dependency pre-bundling treats .jsx files as JSX as well

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68ce36e8e4d88323af3f523472219442