### PR TITLE
Add Tailwind base stylesheet for frontend

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,24 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #f8fafc;
+  color: #0f172a;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+* {
+  box-sizing: border-box;
+}


### PR DESCRIPTION
## Summary
- add the missing `frontend/src/index.css` with Tailwind base layers and simple global defaults

## Testing
- npm run dev -- --clearScreen=false

------
https://chatgpt.com/codex/tasks/task_e_68ce36eb72b083239ab8dfc04ea3c1e3