### PR TITLE
Redirect index route to dashboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { queryClient } from './lib/queryClient';
 import { ThemeProvider } from './contexts/ThemeContext';
@@ -24,7 +24,8 @@ export default function App() {
         <Routes>
           <Route path="/login" element={<Login />} />
           <Route element={<Layout />}>
-            <Route index element={<Dashboard />} />
+            <Route index element={<Navigate to="/dashboard" replace />} />
+            <Route path="dashboard" element={<Dashboard />} />
             <Route path="assets" element={<Assets />} />
             <Route path="work-orders" element={<WorkOrders />} />
             <Route path="pm" element={<PM />} />

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -22,7 +22,7 @@ interface SidebarProps {
 }
 
 const navItems: NavItem[] = [
-  { label: 'Dashboard', to: '/', icon: <LayoutDashboard /> },
+  { label: 'Dashboard', to: '/dashboard', icon: <LayoutDashboard /> },
   { label: 'Assets', to: '/assets', icon: <Boxes /> },
   { label: 'Work Orders', to: '/work-orders', icon: <ClipboardList /> },
   { label: 'Preventive Maintenance', to: '/pm', icon: <CalendarCog /> },


### PR DESCRIPTION
## Summary
- redirect the app's index route to the dashboard and define an explicit /dashboard route
- update the sidebar navigation so the dashboard link targets /dashboard

## Testing
- npm run lint *(fails: invalid --ext option when using eslint.config.js; reran `npx eslint .` but missing dependency `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_68ce3bab4fd4832392b92167fae96332