### PR TITLE
Add NotFound page and route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import Vendors from './pages/Vendors';
 import Documents from './pages/Documents';
 import Analytics from './pages/Analytics';
 import Settings from './pages/Settings';
+import NotFound from './pages/NotFound';
 
 export default function App() {
   return (
@@ -34,6 +35,7 @@ export default function App() {
             <Route path="documents" element={<Documents />} />
             <Route path="analytics" element={<Analytics />} />
             <Route path="settings" element={<Settings />} />
+            <Route path="*" element={<NotFound />} />
           </Route>
         </Routes>
       </QueryClientProvider>

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,0 +1,44 @@
+import { Link } from 'react-router-dom';
+import { useTheme } from '../contexts/ThemeContext';
+
+export default function NotFound() {
+  const { colors } = useTheme();
+
+  return (
+    <div
+      className="flex flex-col items-center justify-center text-center h-full py-24 px-4"
+      style={{ backgroundColor: colors.background }}
+    >
+      <div className="max-w-lg space-y-6">
+        <p className="text-sm font-semibold uppercase tracking-widest" style={{ color: colors.mutedForeground }}>
+          404 Error
+        </p>
+        <h1 className="text-4xl font-bold" style={{ color: colors.foreground }}>
+          We can't find that page
+        </h1>
+        <p className="text-lg" style={{ color: colors.mutedForeground }}>
+          The page you're looking for may have been moved, deleted, or might never have existed.
+        </p>
+        <div className="flex flex-col sm:flex-row gap-3 sm:justify-center">
+          <Link
+            to="/"
+            className="inline-flex items-center justify-center rounded-md px-6 py-3 text-sm font-medium shadow-sm"
+            style={{ backgroundColor: colors.primary, color: colors.primaryForeground }}
+          >
+            Go back home
+          </Link>
+          <Link
+            to="/documents"
+            className="inline-flex items-center justify-center rounded-md px-6 py-3 text-sm font-medium border"
+            style={{
+              color: colors.foreground,
+              borderColor: colors.border
+            }}
+          >
+            View documentation
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a themed 404 NotFound page with links to return home or open documentation
- register the NotFound component on the layout route to catch unmatched paths

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce3bac19a483239725950620f9f3a4