### PR TITLE
Adjust backend defaults for standalone dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ The backend also reads MongoDB connection details from `backend/.env`. By defaul
 npm run dev:all
 ```
 
-This starts both the backend server (localhost:3001) and frontend app (localhost:5173). To run only the frontend, use `npm run dev`.
+This starts both the backend server (localhost:5010) and frontend app (localhost:5173). To run only the frontend, use `npm run dev`.
+
+The API exposes a lightweight readiness probe at `http://localhost:5010/api/health` and a database-specific check at `http://localhost:5010/health/db`.
 
 ### Production Build
 ```bash

--- a/backend/.env
+++ b/backend/.env
@@ -1,4 +1,4 @@
-PORT=3001
+PORT=5010
 MONGO_URI=mongodb://localhost:27017/workpro4
 
 # Example Atlas:

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -17,12 +17,12 @@ import vendorRoutes from './routes/vendors';
 import searchRoutes from './routes/search';
 
 const app = express();
-const PORT = Number(process.env.PORT) || 3001;
+const PORT = Number(process.env.PORT) || 5010;
 
 // Security middleware
 app.use(helmet());
 app.use(cors({
-  origin: process.env.NODE_ENV === 'production' ? process.env.FRONTEND_URL : 'http://localhost:3000',
+  origin: process.env.NODE_ENV === 'production' ? process.env.FRONTEND_URL : 'http://localhost:5173',
   credentials: true,
 }));
 
@@ -42,6 +42,10 @@ app.use(requestLogger);
 
 // Health check
 app.get('/health', (_req, res) => {
+  res.json({ ok: true });
+});
+
+app.get('/api/health', (_req, res) => {
   res.json({ ok: true });
 });
 
@@ -83,21 +87,20 @@ async function start() {
   const databaseUrl = process.env.DATABASE_URL?.trim();
 
   if (!databaseUrl) {
-    console.error('❌ DATABASE_URL environment variable is required');
-    process.exit(1);
-  }
-
-  try {
-    await verifyDatabaseConnection();
-    console.log('🗄️ Connected to database');
-  } catch (error) {
-    console.error('❌ Failed to connect to database', error);
-    process.exit(1);
+    console.warn('⚠️ DATABASE_URL not set. Starting server without database connection.');
+  } else {
+    try {
+      await verifyDatabaseConnection();
+      console.log('🗄️ Connected to database');
+    } catch (error) {
+      console.error('❌ Failed to connect to database', error);
+      process.exit(1);
+    }
   }
 
   app.listen(PORT, () => {
     console.log(`🚀 Backend server running on port ${PORT}`);
-    console.log(`🩺 Health check: http://localhost:${PORT}/health`);
+    console.log(`🩺 Health check: http://localhost:${PORT}/api/health`);
     console.log(`🗄️ DB health: http://localhost:${PORT}/health/db`);
     console.log(`🔐 API base: http://localhost:${PORT}/api`);
   });

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
     port: 5173,
     proxy: {
       '/api': {
-        target: 'http://localhost:3001',
+        target: 'http://localhost:5010',
         changeOrigin: true,
         secure: false,
         rewrite: (p) => p.replace(/^\/api/, '/api'),

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,6 +1,6 @@
 import type { DashboardSummaryResponse } from '../../shared/types/dashboard';
 
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001/api';
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:5010/api';
 
 export interface ApiResult<T> {
   data: T | null;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     port: 5173,
     proxy: {
       '/api': {
-        target: 'http://localhost:3001',
+        target: 'http://localhost:5010',
         changeOrigin: true,
         secure: false,
         rewrite: (path) => path.replace(/^\/api/, '/api')


### PR DESCRIPTION
## Summary
- set the backend development default port to 5010, expose /api/health, and allow the server to boot without DATABASE_URL
- update development CORS and frontend API/proxy defaults to target the new backend port
- refresh documentation to reference the updated port and health check endpoints

## Testing
- npx tsx src/index.ts

------
https://chatgpt.com/codex/tasks/task_e_68ce3baf5f848323af54cba575a2d702