### PR TITLE
Convert vendor shims to ESM exports

### DIFF
--- a/frontend/src/vendor/class-variance-authority.js
+++ b/frontend/src/vendor/class-variance-authority.js
@@ -8,7 +8,7 @@ function resolveVariant(options, key, value) {
   return variantMap[resolved] || ''
 }
 
-function cva(base, options = {}) {
+export function cva(base, options = {}) {
   return function variantFn(props = {}) {
     const classNames = [base]
     const keys = Object.keys(options.variants || {})
@@ -22,7 +22,4 @@ function cva(base, options = {}) {
   }
 }
 
-module.exports = {
-  cva,
-  default: cva,
-}
+export default cva

--- a/frontend/src/vendor/clsx.js
+++ b/frontend/src/vendor/clsx.js
@@ -12,11 +12,8 @@ function toClass(value) {
   return ''
 }
 
-function clsx(...inputs) {
+export function clsx(...inputs) {
   return inputs.map(toClass).filter(Boolean).join(' ')
 }
 
-module.exports = {
-  clsx,
-  default: clsx,
-}
+export default clsx

--- a/frontend/src/vendor/react-select.js
+++ b/frontend/src/vendor/react-select.js
@@ -1,39 +1,39 @@
-const React = require('react')
+import React from 'react'
 
-const Root = ({ children }) => React.createElement('div', null, children)
-const Group = ({ children }) => React.createElement('div', null, children)
-const Value = ({ children }) => React.createElement('span', null, children)
+export const Root = ({ children }) => React.createElement('div', null, children)
+export const Group = ({ children }) => React.createElement('div', null, children)
+export const Value = ({ children }) => React.createElement('span', null, children)
 
-const Trigger = React.forwardRef(({ children, ...props }, ref) =>
+export const Trigger = React.forwardRef(({ children, ...props }, ref) =>
   React.createElement('button', { type: 'button', ref, ...props }, children),
 )
 
-const Icon = ({ asChild, children }) => (asChild ? children : React.createElement('span', null, children))
-const ScrollUpButton = React.forwardRef(({ children, ...props }, ref) =>
+export const Icon = ({ asChild, children }) => (asChild ? children : React.createElement('span', null, children))
+export const ScrollUpButton = React.forwardRef(({ children, ...props }, ref) =>
   React.createElement('button', { type: 'button', ref, ...props }, children),
 )
-const ScrollDownButton = React.forwardRef(({ children, ...props }, ref) =>
+export const ScrollDownButton = React.forwardRef(({ children, ...props }, ref) =>
   React.createElement('button', { type: 'button', ref, ...props }, children),
 )
 
-const Portal = ({ children }) => React.createElement(React.Fragment, null, children)
-const Content = React.forwardRef(({ children, ...props }, ref) =>
+export const Portal = ({ children }) => React.createElement(React.Fragment, null, children)
+export const Content = React.forwardRef(({ children, ...props }, ref) =>
   React.createElement('div', { ref, ...props }, children),
 )
-const Viewport = ({ children, ...props }) => React.createElement('div', { ...props }, children)
+export const Viewport = ({ children, ...props }) => React.createElement('div', { ...props }, children)
 
-const Item = React.forwardRef(({ children, ...props }, ref) =>
+export const Item = React.forwardRef(({ children, ...props }, ref) =>
   React.createElement('div', { role: 'option', ref, ...props }, children),
 )
-const ItemIndicator = ({ children }) => React.createElement('span', null, children)
-const ItemText = ({ children }) => React.createElement('span', null, children)
+export const ItemIndicator = ({ children }) => React.createElement('span', null, children)
+export const ItemText = ({ children }) => React.createElement('span', null, children)
 
-const Label = React.forwardRef(({ children, ...props }, ref) =>
+export const Label = React.forwardRef(({ children, ...props }, ref) =>
   React.createElement('div', { ref, ...props }, children),
 )
-const Separator = React.forwardRef((props, ref) => React.createElement('div', { ref, ...props }))
+export const Separator = React.forwardRef((props, ref) => React.createElement('div', { ref, ...props }))
 
-module.exports = {
+const SelectPrimitive = {
   Root,
   Group,
   Value,
@@ -50,3 +50,5 @@ module.exports = {
   Label,
   Separator,
 }
+
+export default SelectPrimitive

--- a/frontend/src/vendor/react-slot.js
+++ b/frontend/src/vendor/react-slot.js
@@ -1,6 +1,6 @@
-const React = require('react')
+import React from 'react'
 
-const Slot = React.forwardRef(({ children, ...props }, ref) => {
+export const Slot = React.forwardRef(({ children, ...props }, ref) => {
   if (React.isValidElement(children)) {
     return React.cloneElement(children, { ...props, ref })
   }
@@ -9,7 +9,4 @@ const Slot = React.forwardRef(({ children, ...props }, ref) => {
 
 Slot.displayName = 'Slot'
 
-module.exports = {
-  Slot,
-  default: Slot,
-}
+export default Slot

--- a/frontend/src/vendor/react-tabs.js
+++ b/frontend/src/vendor/react-tabs.js
@@ -1,4 +1,4 @@
-const React = require('react')
+import React from 'react'
 
 const TabsContext = React.createContext(null)
 
@@ -10,7 +10,7 @@ function useTabsContext() {
   return ctx
 }
 
-function TabsRoot({ defaultValue, value, onValueChange, children }) {
+export function Root({ defaultValue, value, onValueChange, children }) {
   const isControlled = value !== undefined
   const [internalValue, setInternalValue] = React.useState(defaultValue)
 
@@ -29,11 +29,11 @@ function TabsRoot({ defaultValue, value, onValueChange, children }) {
   return React.createElement(TabsContext.Provider, { value: contextValue }, children)
 }
 
-const TabsList = React.forwardRef(({ children, ...props }, ref) =>
+export const List = React.forwardRef(({ children, ...props }, ref) =>
   React.createElement('div', { role: 'tablist', ref, ...props }, children),
 )
 
-const TabsTrigger = React.forwardRef(({ value, children, onClick, ...props }, ref) => {
+export const Trigger = React.forwardRef(({ value, children, onClick, ...props }, ref) => {
   const { value: activeValue, setValue } = useTabsContext()
   const isActive = activeValue === value
 
@@ -55,7 +55,7 @@ const TabsTrigger = React.forwardRef(({ value, children, onClick, ...props }, re
   )
 })
 
-const TabsContent = React.forwardRef(({ value, children, ...props }, ref) => {
+export const Content = React.forwardRef(({ value, children, ...props }, ref) => {
   const { value: activeValue } = useTabsContext()
   if (activeValue !== value) {
     return null
@@ -63,9 +63,11 @@ const TabsContent = React.forwardRef(({ value, children, ...props }, ref) => {
   return React.createElement('div', { role: 'tabpanel', ref, ...props }, children)
 })
 
-module.exports = {
-  Root: TabsRoot,
-  List: TabsList,
-  Trigger: TabsTrigger,
-  Content: TabsContent,
+const TabsPrimitive = {
+  Root,
+  List,
+  Trigger,
+  Content,
 }
+
+export default TabsPrimitive

--- a/frontend/src/vendor/tailwind-merge.js
+++ b/frontend/src/vendor/tailwind-merge.js
@@ -1,8 +1,5 @@
-function twMerge(...classLists) {
+export function twMerge(...classLists) {
   return classLists.filter(Boolean).join(' ')
 }
 
-module.exports = {
-  twMerge,
-  default: twMerge,
-}
+export default twMerge


### PR DESCRIPTION
## Summary
- convert the clsx, tailwind-merge, and class-variance-authority shims to use ESM named/default exports
- update the Radix UI shim modules to import React with ESM syntax and expose named and default exports

## Testing
- CI=1 npm run dev -- --clearScreen false

------
https://chatgpt.com/codex/tasks/task_e_68ce44a39f008323aaa200e619c99160