### PR TITLE
Add work order filters panel and filtering logic

### DIFF
--- a/src/pages/WorkOrders.tsx
+++ b/src/pages/WorkOrders.tsx
@@ -1,8 +1,18 @@
+import { useMemo, useState } from 'react';
 import { ClipboardList, Plus, Search, Filter, User, Calendar, AlertTriangle } from 'lucide-react';
 import { useTheme } from '../contexts/ThemeContext';
 
 export default function WorkOrders() {
   const { colors } = useTheme();
+
+  const [showFilters, setShowFilters] = useState(false);
+  const [filters, setFilters] = useState({
+    status: '',
+    priority: '',
+    assignee: '',
+    dateFrom: '',
+    dateTo: ''
+  });
 
   const statusStats = [
     { label: 'Open', count: 24, color: colors.info },
@@ -11,7 +21,22 @@ export default function WorkOrders() {
     { label: 'Overdue', count: 3, color: colors.error }
   ];
 
-  const workOrders = [
+  type WorkOrder = {
+    id: string;
+    title: string;
+    description: string;
+    priority: string;
+    status: string;
+    asset: string;
+    assignee: string;
+    dueDate: string;
+    createdDate: string;
+    dueDateValue: string;
+    createdDateValue: string;
+  };
+
+  const workOrders = useMemo<WorkOrder[]>(
+    () => [
     {
       id: 'WO-2024-001',
       title: 'Motor Overheating - Emergency Repair',
@@ -21,7 +46,9 @@ export default function WorkOrders() {
       asset: 'Drive Motor #1',
       assignee: 'John Smith',
       dueDate: 'Today',
-      createdDate: '2 hours ago'
+      createdDate: '2 hours ago',
+      dueDateValue: '2024-03-05',
+      createdDateValue: '2024-03-04T08:00:00.000Z'
     },
     {
       id: 'WO-2024-002',
@@ -32,7 +59,9 @@ export default function WorkOrders() {
       asset: 'Hydraulic Pump #1',
       assignee: 'Jane Doe',
       dueDate: 'Yesterday',
-      createdDate: '3 days ago'
+      createdDate: '3 days ago',
+      dueDateValue: '2024-03-03',
+      createdDateValue: '2024-03-01T12:00:00.000Z'
     },
     {
       id: 'WO-2024-003',
@@ -43,9 +72,50 @@ export default function WorkOrders() {
       asset: 'Conveyor Belt #1',
       assignee: 'Unassigned',
       dueDate: 'Next week',
-      createdDate: '1 day ago'
+      createdDate: '1 day ago',
+      dueDateValue: '2024-03-10',
+      createdDateValue: '2024-03-03T09:30:00.000Z'
     }
-  ];
+  ], []);
+
+  const statusOptions = useMemo(
+    () => Array.from(new Set(workOrders.map((wo) => wo.status))).sort(),
+    [workOrders]
+  );
+
+  const priorityOptions = useMemo(
+    () => Array.from(new Set(workOrders.map((wo) => wo.priority))).sort(),
+    [workOrders]
+  );
+
+  const assigneeOptions = useMemo(
+    () => Array.from(new Set(workOrders.map((wo) => wo.assignee))).sort(),
+    [workOrders]
+  );
+
+  const filteredWorkOrders = useMemo(() => {
+    return workOrders.filter((wo) => {
+      const matchesStatus = filters.status ? wo.status === filters.status : true;
+      const matchesPriority = filters.priority ? wo.priority === filters.priority : true;
+      const matchesAssignee = filters.assignee ? wo.assignee === filters.assignee : true;
+
+      const createdDate = new Date(wo.createdDateValue);
+      const matchesDateFrom = filters.dateFrom ? createdDate >= new Date(filters.dateFrom) : true;
+      const matchesDateTo = filters.dateTo ? createdDate <= new Date(filters.dateTo) : true;
+
+      return (
+        matchesStatus &&
+        matchesPriority &&
+        matchesAssignee &&
+        matchesDateFrom &&
+        matchesDateTo
+      );
+    });
+  }, [filters, workOrders]);
+
+  const handleFilterChange = (key: keyof typeof filters, value: string) => {
+    setFilters((prev) => ({ ...prev, [key]: value }));
+  };
 
   const getPriorityColor = (priority: string) => {
     switch (priority) {
@@ -119,19 +189,139 @@ export default function WorkOrders() {
             }}
           />
         </div>
-        <button 
+        <button
           className="flex items-center gap-2 px-4 py-2 border rounded-xl hover:bg-opacity-80 transition-colors"
           style={{ borderColor: colors.border, color: colors.foreground }}
+          onClick={() => setShowFilters((prev) => !prev)}
         >
           <Filter className="w-4 h-4" />
           Filters
         </button>
       </div>
 
+      {showFilters && (
+        <div
+          className="rounded-xl border p-4 grid gap-4 md:grid-cols-2 xl:grid-cols-4"
+          style={{ backgroundColor: colors.card, borderColor: colors.border }}
+        >
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium" style={{ color: colors.foreground }}>
+              Status
+            </label>
+            <select
+              value={filters.status}
+              onChange={(event) => handleFilterChange('status', event.target.value)}
+              className="h-10 px-3 rounded-xl border focus:outline-none focus:ring-2 focus:ring-ring"
+              style={{
+                backgroundColor: colors.background,
+                borderColor: colors.border,
+                color: colors.foreground
+              }}
+            >
+              <option value="">All</option>
+              {statusOptions.map((status) => (
+                <option key={status} value={status}>
+                  {status}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium" style={{ color: colors.foreground }}>
+              Priority
+            </label>
+            <select
+              value={filters.priority}
+              onChange={(event) => handleFilterChange('priority', event.target.value)}
+              className="h-10 px-3 rounded-xl border focus:outline-none focus:ring-2 focus:ring-ring"
+              style={{
+                backgroundColor: colors.background,
+                borderColor: colors.border,
+                color: colors.foreground
+              }}
+            >
+              <option value="">All</option>
+              {priorityOptions.map((priority) => (
+                <option key={priority} value={priority}>
+                  {priority}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium" style={{ color: colors.foreground }}>
+              Assignee
+            </label>
+            <select
+              value={filters.assignee}
+              onChange={(event) => handleFilterChange('assignee', event.target.value)}
+              className="h-10 px-3 rounded-xl border focus:outline-none focus:ring-2 focus:ring-ring"
+              style={{
+                backgroundColor: colors.background,
+                borderColor: colors.border,
+                color: colors.foreground
+              }}
+            >
+              <option value="">All</option>
+              {assigneeOptions.map((assignee) => (
+                <option key={assignee} value={assignee}>
+                  {assignee}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium" style={{ color: colors.foreground }}>
+              Created Date
+            </label>
+            <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+              <input
+                type="date"
+                value={filters.dateFrom}
+                onChange={(event) => handleFilterChange('dateFrom', event.target.value)}
+                className="h-10 px-3 rounded-xl border focus:outline-none focus:ring-2 focus:ring-ring"
+                style={{
+                  backgroundColor: colors.background,
+                  borderColor: colors.border,
+                  color: colors.foreground
+                }}
+              />
+              <input
+                type="date"
+                value={filters.dateTo}
+                onChange={(event) => handleFilterChange('dateTo', event.target.value)}
+                className="h-10 px-3 rounded-xl border focus:outline-none focus:ring-2 focus:ring-ring"
+                style={{
+                  backgroundColor: colors.background,
+                  borderColor: colors.border,
+                  color: colors.foreground
+                }}
+              />
+            </div>
+          </div>
+
+          <div className="md:col-span-2 xl:col-span-4 flex flex-wrap justify-end gap-2">
+            <button
+              type="button"
+              className="px-4 py-2 border rounded-xl text-sm hover:bg-opacity-80 transition-colors"
+              style={{ borderColor: colors.border, color: colors.foreground }}
+              onClick={() =>
+                setFilters({ status: '', priority: '', assignee: '', dateFrom: '', dateTo: '' })
+              }
+            >
+              Reset Filters
+            </button>
+          </div>
+        </div>
+      )}
+
       {/* Work Orders List */}
       <div className="space-y-4">
-        {workOrders.map((wo) => (
-          <div 
+        {filteredWorkOrders.map((wo) => (
+          <div
             key={wo.id}
             className="rounded-xl border p-6 shadow-sm hover:shadow-md transition-shadow cursor-pointer"
             style={{ backgroundColor: colors.card, borderColor: colors.border }}


### PR DESCRIPTION
## Summary
- add toggleable filters panel for work orders and bind controls to component state
- derive filter options from the work order data set and support resetting selections
- filter the work order list client-side based on status, priority, assignee, and created date range selections

## Testing
- pnpm lint *(fails: Invalid option '--ext' when using eslint.config.js)*
- pnpm exec eslint . *(fails: missing dependency @eslint/js referenced by config)*

------
https://chatgpt.com/codex/tasks/task_e_68ce4891e78c83239bab9e5e5e4cc94b