### PR TITLE
feat: add work order creation form

### DIFF
--- a/frontend/src/components/work-orders/WorkOrderForm.jsx
+++ b/frontend/src/components/work-orders/WorkOrderForm.jsx
@@ -1,0 +1,294 @@
+import { useMemo, useState } from 'react';
+import { useFieldArray, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { api } from '@/lib/api';
+
+const workOrderSchema = z.object({
+  title: z.string().min(1, 'Title is required'),
+  description: z.string().min(1, 'Description is required'),
+  priority: z.enum(['low', 'medium', 'high', 'urgent'], {
+    errorMap: () => ({ message: 'Select a priority' }),
+  }),
+  assetId: z.string().min(1, 'Asset is required'),
+  assignees: z
+    .array(z.string().min(1, 'Assignee is required'))
+    .min(1, 'Add at least one assignee'),
+  checklists: z
+    .array(
+      z.object({
+        text: z.string().min(1, 'Checklist item is required'),
+        note: z.string().optional(),
+      })
+    )
+    .min(1, 'Add at least one checklist item'),
+});
+
+export function WorkOrderForm({ onClose, onSuccess }) {
+  const [submitError, setSubmitError] = useState('');
+  const form = useForm({
+    resolver: zodResolver(workOrderSchema),
+    defaultValues: {
+      title: '',
+      description: '',
+      priority: 'medium',
+      assetId: '',
+      assignees: [''],
+      checklists: [{ text: '', note: '' }],
+    },
+  });
+
+  const {
+    control,
+    handleSubmit,
+    register,
+    setError,
+    formState: { errors, isSubmitting },
+    reset,
+  } = form;
+
+  const assigneeFields = useFieldArray({ control, name: 'assignees' });
+  const checklistFields = useFieldArray({ control, name: 'checklists' });
+
+  const priorityOptions = useMemo(
+    () => [
+      { value: 'low', label: 'Low' },
+      { value: 'medium', label: 'Medium' },
+      { value: 'high', label: 'High' },
+      { value: 'urgent', label: 'Urgent' },
+    ],
+    []
+  );
+
+  const handleApiErrors = (error) => {
+    if (!error) return;
+
+    if (Array.isArray(error.details)) {
+      error.details.forEach((detail) => {
+        if (!detail?.path) return;
+        const fieldPath = Array.isArray(detail.path)
+          ? detail.path.join('.')
+          : detail.path;
+
+        if (fieldPath) {
+          setError(fieldPath, {
+            type: 'server',
+            message: detail.message || error.message || 'Validation error',
+          });
+        }
+      });
+    }
+
+    setSubmitError(error.message || 'Unable to create work order');
+  };
+
+  const onSubmit = handleSubmit(async (values) => {
+    setSubmitError('');
+
+    const payload = {
+      title: values.title,
+      description: values.description,
+      priority: values.priority,
+      assetId: values.assetId,
+      assignees: values.assignees.filter((id) => id.trim().length > 0),
+      checklists: values.checklists
+        .filter((item) => item.text.trim().length > 0)
+        .map((item) => ({
+          text: item.text,
+          note: item.note || undefined,
+        })),
+    };
+
+    const result = await api.post('/work-orders', payload);
+
+    if (result?.error) {
+      handleApiErrors(result.error);
+      return;
+    }
+
+    reset();
+    if (typeof onSuccess === 'function') {
+      onSuccess(result?.data);
+    }
+  });
+
+  return (
+    <form className="space-y-6" onSubmit={onSubmit}>
+      <div className="space-y-2">
+        <label className="block text-sm font-medium text-gray-700">Title</label>
+        <Input placeholder="Work order title" {...register('title')} />
+        {errors.title && (
+          <p className="text-sm text-red-600">{errors.title.message}</p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <label className="block text-sm font-medium text-gray-700">Description</label>
+        <textarea
+          {...register('description')}
+          className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          rows={4}
+          placeholder="Describe the work to be completed"
+        />
+        {errors.description && (
+          <p className="text-sm text-red-600">{errors.description.message}</p>
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-gray-700">Priority</label>
+          <select
+            {...register('priority')}
+            className="w-full rounded-md border border-input bg-white px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          >
+            <option value="">Select priority</option>
+            {priorityOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          {errors.priority && (
+            <p className="text-sm text-red-600">{errors.priority.message}</p>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-gray-700">Asset ID</label>
+          <Input placeholder="Asset identifier" {...register('assetId')} />
+          {errors.assetId && (
+            <p className="text-sm text-red-600">{errors.assetId.message}</p>
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <div>
+            <h3 className="text-sm font-medium text-gray-900">Assignees</h3>
+            <p className="text-sm text-gray-500">
+              Assign at least one technician or team member responsible for this work.
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => assigneeFields.append('')}
+          >
+            Add Assignee
+          </Button>
+        </div>
+        {errors.assignees && !Array.isArray(errors.assignees) && (
+          <p className="text-sm text-red-600">{errors.assignees.message}</p>
+        )}
+        <div className="space-y-3">
+          {assigneeFields.fields.map((field, index) => (
+            <div key={field.id} className="flex items-center space-x-2">
+              <Input
+                placeholder="Assignee ID or email"
+                {...register(`assignees.${index}`)}
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => assigneeFields.remove(index)}
+                disabled={assigneeFields.fields.length === 1}
+              >
+                Remove
+              </Button>
+            </div>
+          ))}
+        </div>
+        {Array.isArray(errors.assignees) &&
+          errors.assignees.map((assigneeError, index) =>
+            assigneeError ? (
+              <p key={`assignee-error-${index}`} className="text-sm text-red-600">
+                {assigneeError.message}
+              </p>
+            ) : null
+          )}
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <div>
+            <h3 className="text-sm font-medium text-gray-900">Checklist</h3>
+            <p className="text-sm text-gray-500">
+              Outline the tasks that must be completed for this work order.
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => checklistFields.append({ text: '', note: '' })}
+          >
+            Add Item
+          </Button>
+        </div>
+        {errors.checklists && !Array.isArray(errors.checklists) && (
+          <p className="text-sm text-red-600">{errors.checklists.message}</p>
+        )}
+        <div className="space-y-4">
+          {checklistFields.fields.map((field, index) => (
+            <div key={field.id} className="space-y-2 rounded-lg border border-border p-4">
+              <div className="flex items-start justify-between">
+                <div className="flex-1 space-y-2">
+                  <label className="block text-sm font-medium text-gray-700">
+                    Item
+                  </label>
+                  <Input
+                    placeholder="Checklist task"
+                    {...register(`checklists.${index}.text`)}
+                  />
+                  {errors.checklists?.[index]?.text && (
+                    <p className="text-sm text-red-600">
+                      {errors.checklists[index].text.message}
+                    </p>
+                  )}
+                  <label className="block text-sm font-medium text-gray-700">
+                    Note (optional)
+                  </label>
+                  <textarea
+                    {...register(`checklists.${index}.note`)}
+                    className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                    rows={2}
+                    placeholder="Add guidance or notes for this task"
+                  />
+                  {errors.checklists?.[index]?.note && (
+                    <p className="text-sm text-red-600">
+                      {errors.checklists[index].note.message}
+                    </p>
+                  )}
+                </div>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  className="ml-4"
+                  onClick={() => checklistFields.remove(index)}
+                  disabled={checklistFields.fields.length === 1}
+                >
+                  Remove
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {submitError && <p className="text-sm text-red-600">{submitError}</p>}
+
+      <div className="flex items-center justify-end space-x-3">
+        <Button type="button" variant="outline" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button type="submit" disabled={isSubmitting}>
+          {isSubmitting ? 'Creating…' : 'Create Work Order'}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/pages/WorkOrders.jsx
+++ b/frontend/src/pages/WorkOrders.jsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   Calendar,
   Filter,
   Plus,
   Search,
+  X,
   User,
   Wrench,
 } from 'lucide-react';
@@ -13,12 +14,15 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
+import { WorkOrderForm } from '@/components/work-orders/WorkOrderForm';
 import { api } from '@/lib/api';
 import { formatDate, getPriorityColor, getStatusColor } from '@/lib/utils';
 
 export function WorkOrders() {
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState('');
+  const [showCreate, setShowCreate] = useState(false);
+  const queryClient = useQueryClient();
 
   const {
     data,
@@ -62,7 +66,7 @@ export function WorkOrders() {
           <h1 className="text-3xl font-bold text-gray-900">Work Orders</h1>
           <p className="text-gray-500">Manage and track maintenance work orders</p>
         </div>
-        <Button className="flex items-center">
+        <Button className="flex items-center" onClick={() => setShowCreate(true)}>
           <Plus className="w-4 h-4 mr-2" />
           New Work Order
         </Button>
@@ -199,12 +203,44 @@ export function WorkOrders() {
                 ? 'Try adjusting your search or filter criteria'
                 : 'Get started by creating your first work order'}
             </p>
-            <Button>
+            <Button onClick={() => setShowCreate(true)}>
               <Plus className="w-4 h-4 mr-2" />
               New Work Order
             </Button>
           </CardContent>
         </Card>
+      )}
+
+      {showCreate && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+          <div className="bg-white rounded-lg shadow-xl w-full max-w-3xl max-h-[90vh] overflow-hidden flex flex-col">
+            <div className="flex items-center justify-between border-b px-6 py-4">
+              <div>
+                <h2 className="text-xl font-semibold text-gray-900">Create Work Order</h2>
+                <p className="text-sm text-gray-500">
+                  Provide the details below to add a new work order.
+                </p>
+              </div>
+              <button
+                type="button"
+                aria-label="Close"
+                onClick={() => setShowCreate(false)}
+                className="p-2 rounded-md text-gray-500 hover:text-gray-700 hover:bg-gray-100"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+            <div className="overflow-y-auto px-6 py-4">
+              <WorkOrderForm
+                onClose={() => setShowCreate(false)}
+                onSuccess={() => {
+                  setShowCreate(false);
+                  queryClient.invalidateQueries({ queryKey: ['work-orders'] });
+                }}
+              />
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/package.json
+++ b/package.json
@@ -12,11 +12,14 @@
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
   },
   "dependencies": {
+    "@hookform/resolvers": "^3.9.0",
     "@tanstack/react-query": "^4.41.0",
     "lucide-react": "^0.544.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-hook-form": "^7.53.0",
     "react-router-dom": "^6.30.1",
+    "zod": "^3.23.8",
     "zustand": "^5.0.8"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- add a creation dialog to the Work Orders page and refresh the list after new submissions
- implement a react-hook-form + zod powered WorkOrderForm component that posts to the API and surfaces validation feedback
- declare the new form dependencies in package.json

## Testing
- npm run lint *(fails: Invalid option '--ext' due to eslint flat config)*

------
https://chatgpt.com/codex/tasks/task_e_68ce54e229488323b301a7790ec62463