### PR TITLE
Fix work orders modal dependencies

### DIFF
--- a/frontend/src/pages/WorkOrders.jsx
+++ b/frontend/src/pages/WorkOrders.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 
 import {
   Calendar,
@@ -10,6 +10,8 @@ import {
   User,
   Wrench,
 } from 'lucide-react';
+
+import { WorkOrderForm } from '@/components/work-orders/WorkOrderForm';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -44,12 +46,15 @@ export function WorkOrders() {
   const [tempFilters, setTempFilters] = useState(() => ({
     ...INITIAL_ADVANCED_FILTERS,
   }));
+  const [showCreate, setShowCreate] = useState(false);
 
   useEffect(() => {
     if (isFiltersOpen) {
       setTempFilters({ ...advancedFilters });
     }
   }, [isFiltersOpen, advancedFilters]);
+
+  const queryClient = useQueryClient();
 
 
   const {


### PR DESCRIPTION
## Summary
- add the missing modal state and WorkOrderForm import so the create modal renders
- instantiate a React Query client for invalidating the work orders list after creation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce659b5670832382116380c8951fdc