### PR TITLE
Ensure JWT secrets are validated at startup

### DIFF
--- a/backend/src/config/auth.test.ts
+++ b/backend/src/config/auth.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { loadJwtConfig } from './auth';
+
+describe('loadJwtConfig', () => {
+  it('throws an error when JWT_SECRET is missing', () => {
+    const env = { ...process.env } as NodeJS.ProcessEnv;
+    delete env.JWT_SECRET;
+
+    expect(() => loadJwtConfig(env)).toThrowError('JWT_SECRET environment variable is required and must not be empty');
+  });
+});

--- a/backend/src/config/auth.ts
+++ b/backend/src/config/auth.ts
@@ -1,0 +1,57 @@
+export interface JwtConfig {
+  secret: string;
+  refreshSecret?: string;
+}
+
+function normalize(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export function loadJwtConfig(env: NodeJS.ProcessEnv = process.env): JwtConfig {
+  const secret = normalize(env.JWT_SECRET);
+  if (!secret) {
+    throw new Error('JWT_SECRET environment variable is required and must not be empty');
+  }
+
+  const refreshSecretRaw = env.JWT_REFRESH_SECRET;
+  const refreshSecret = refreshSecretRaw === undefined ? undefined : normalize(refreshSecretRaw);
+
+  if (refreshSecretRaw !== undefined && !refreshSecret) {
+    throw new Error('JWT_REFRESH_SECRET environment variable must not be empty when provided');
+  }
+
+  return { secret, refreshSecret };
+}
+
+let cachedConfig: JwtConfig | null = null;
+
+export function getJwtConfig(): JwtConfig {
+  if (!cachedConfig) {
+    cachedConfig = loadJwtConfig();
+  }
+  return cachedConfig;
+}
+
+export function ensureJwtSecrets(options: { requireRefresh?: boolean } = {}): void {
+  const config = getJwtConfig();
+  if (options.requireRefresh && !config.refreshSecret) {
+    throw new Error('JWT_REFRESH_SECRET environment variable is required but was not provided');
+  }
+}
+
+export function getJwtSecret(): string {
+  return getJwtConfig().secret;
+}
+
+export function getJwtRefreshSecret(options: { required?: boolean } = {}): string | undefined {
+  const refreshSecret = getJwtConfig().refreshSecret;
+  if (options.required && !refreshSecret) {
+    throw new Error('JWT_REFRESH_SECRET environment variable is required but was not provided');
+  }
+  return refreshSecret;
+}
+
+export function resetJwtConfigCache(): void {
+  cachedConfig = null;
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -6,6 +6,7 @@ import rateLimit from 'express-rate-limit';
 import { requestLogger } from './middleware/requestLogger';
 import { errorHandler } from './middleware/errorHandler';
 import { prisma, verifyDatabaseConnection } from './db';
+import { ensureJwtSecrets } from './config/auth';
 
 // Routes
 import authRoutes from './routes/auth';
@@ -84,6 +85,14 @@ app.use('*', (req, res) => {
 });
 
 async function start() {
+  try {
+    ensureJwtSecrets();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error validating JWT configuration';
+    console.error(`❌ ${message}`);
+    process.exit(1);
+  }
+
   const databaseUrl = process.env.DATABASE_URL?.trim();
 
   if (!databaseUrl) {

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -2,6 +2,7 @@ import { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
 import { PrismaClient } from '@prisma/client';
 import { fail } from '../utils/response';
+import { getJwtSecret } from '../config/auth';
 
 const prisma = new PrismaClient();
 
@@ -23,7 +24,7 @@ export function authenticateToken(req: AuthRequest, res: Response, next: NextFun
     return fail(res, 401, 'Access token required');
   }
 
-  jwt.verify(token, process.env.JWT_SECRET!, async (err: any, decoded: any) => {
+  jwt.verify(token, getJwtSecret(), async (err: any, decoded: any) => {
     if (err) {
       return fail(res, 403, 'Invalid or expired token');
     }

--- a/backend/src/routes/__tests__/inventory.test.ts
+++ b/backend/src/routes/__tests__/inventory.test.ts
@@ -85,8 +85,8 @@ describe('inventory-related routes', () => {
     });
 
     const response = json.mock.calls[0][0];
-    expect(response.data.partsCount).toBe(6);
-    expect(response.data.stockHealth).toBeCloseTo(66.7, 1);
+    expect(response.data.inventory.totalParts).toBe(6);
+    expect(response.data.inventory.stockHealth).toBeCloseTo(66.7, 1);
   });
 
   it('filters parts below minimum stock level when requested', async () => {

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { PrismaClient } from '@prisma/client';
 import { ok, fail, asyncHandler } from '../utils/response';
 import { authenticateToken, AuthRequest } from '../middleware/auth';
+import { getJwtSecret } from '../config/auth';
 
 const router = Router();
 const prisma = new PrismaClient();
@@ -30,7 +31,7 @@ router.post('/login', asyncHandler(async (req, res) => {
 
   const token = jwt.sign(
     { userId: user.id, tenantId: user.tenantId },
-    process.env.JWT_SECRET!,
+    getJwtSecret(),
     { expiresIn: '24h' }
   );
 


### PR DESCRIPTION
## Summary
- add a dedicated auth config module that validates and exposes JWT secrets
- fail server startup when required JWT secrets are missing
- centralize JWT secret usage in auth routes and middleware and add regression test for missing secrets
- align inventory route test expectations with current dashboard summary structure

## Testing
- npm run --prefix backend test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68ce7f6c531483238145198e0cb39fa0