### PR TITLE
Import getJwtSecret in auth routes

### DIFF
--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { ok, fail, asyncHandler } from '../utils/response';
 import { authenticateToken, AuthRequest } from '../middleware/auth';
 import { prisma } from '../db';
+import { getJwtSecret } from '../config/auth';
 
 
 const router = Router();


### PR DESCRIPTION
## Summary
- import the getJwtSecret helper in the auth route module so token signing works

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce9b397ec48323935df8c2a0390b35