### PR TITLE
Add JWT secrets to backend env

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -3,3 +3,6 @@ MONGO_URI=mongodb://localhost:27017/workpro4
 
 # Example Atlas:
 # MONGO_URI=mongodb+srv://<user>:<pass>@<cluster>.mongodb.net/workpro4?retryWrites=true&w=majority
+
+JWT_SECRET=dev_secret_change_in_production
+JWT_REFRESH_SECRET=dev_refresh_secret_change_in_production


### PR DESCRIPTION
## Summary
- add JWT secret defaults to the backend development environment file for local auth configuration

## Testing
- npm run dev -- --clear-screen=false *(fails: DATABASE_URL environment variable is required)*

------
https://chatgpt.com/codex/tasks/task_e_68ce9b3834208323a75a9b25b99f1c99