### PR TITLE
Update backend port example to 5010

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -9,4 +9,4 @@ JWT_REFRESH_SECRET=dev_refresh_secret_change_in_production
 MAILDEV_HOST=localhost
 MAILDEV_PORT=1025
 NODE_ENV=development
-PORT=3001
+PORT=5010


### PR DESCRIPTION
## Summary
- update the backend example environment file so the PORT matches the 5010 value used by the frontend proxy and docs

## Testing
- not run (doc/config change only)

------
https://chatgpt.com/codex/tasks/task_e_68cea475f6a08323963812cd5099c727