### PR TITLE
Update backend env to use Postgres database URL

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -1,8 +1,5 @@
 PORT=5010
-MONGO_URI=mongodb://localhost:27017/workpro4
-
-# Example Atlas:
-# MONGO_URI=mongodb+srv://<user>:<pass>@<cluster>.mongodb.net/workpro4?retryWrites=true&w=majority
+DATABASE_URL=postgresql://postgres:password@localhost:5432/workpro_dev
 
 JWT_SECRET=dev_secret_change_in_production
 JWT_REFRESH_SECRET=dev_refresh_secret_change_in_production


### PR DESCRIPTION
## Summary
- replace the MongoDB URI in backend/.env with the local Postgres DATABASE_URL to match the example configuration

## Testing
- pnpm tsx src/index.ts (backend)


------
https://chatgpt.com/codex/tasks/task_e_68ceb964b3a883239c80551d9a6ec45a