### PR TITLE
Switch Prisma scripts to db push for Mongo

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ docker-compose up -d
 # Copy environment file
 cp backend/.env.example backend/.env
 
-# Run migrations
-cd backend && npm run db:migrate
+# Synchronize the database schema
+cd backend && npm run db:push
 
 # Seed with demo data
 npm run db:seed

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,9 +9,9 @@
     "start": "node dist/index.js",
     "test": "vitest",
     "db:generate": "prisma generate",
-    "db:migrate": "prisma migrate dev",
+    "db:push": "prisma db push",
     "db:seed": "tsx src/scripts/seed.ts",
-    "db:reset": "prisma migrate reset --force",
+    "db:reset": "prisma db push --force-reset",
     "lint": "eslint src --ext .ts",
     "format": "prettier --write src"
   },


### PR DESCRIPTION
## Summary
- swap the prisma migration script to use `prisma db push` for Mongo compatibility
- update the reset script and README instructions to reference the new push workflow

## Testing
- npm run --prefix backend db:push *(fails: MongoDB connection refused in container)*
- npm run --prefix backend db:reset *(fails: MongoDB connection refused in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cfa24208208323baf4c35f0f7c307d