### PR TITLE
Load backend .env explicitly

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,5 @@
+# Backend Environment Configuration
+
+The backend server automatically loads environment variables from `backend/.env` on startup using `dotenv`. Any variables already
+present in the real environment will continue to take precedence, so you can override the `.env` defaults via the shell or your
+hosting platform when needed.

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,4 +1,5 @@
-import 'dotenv/config';
+import path from 'path';
+import dotenv from 'dotenv';
 import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
@@ -16,6 +17,12 @@ import assetRoutes from './routes/assets';
 import partRoutes from './routes/parts';
 import vendorRoutes from './routes/vendors';
 import searchRoutes from './routes/search';
+
+const envPath = path.resolve(__dirname, '../.env');
+
+// Load environment variables from backend/.env while still allowing real environment
+// variables to take precedence when they are already defined.
+const dotenvResult = dotenv.config({ path: envPath });
 
 const app = express();
 const PORT = Number(process.env.PORT) || 5010;
@@ -94,7 +101,8 @@ async function start() {
     process.exit(1);
   }
 
-  const databaseUrl = process.env.DATABASE_URL?.trim();
+  const databaseUrl =
+    process.env.DATABASE_URL?.trim() ?? dotenvResult.parsed?.DATABASE_URL?.trim();
 
   if (!databaseUrl) {
     console.error('❌ DATABASE_URL environment variable is required. Shutting down.');


### PR DESCRIPTION
## Summary
- replace the backend's side-effect dotenv import with an explicit configuration that reads backend/.env while leaving real environment variables in control
- keep DATABASE_URL resolution working even when only process.env is populated
- document the automatic backend/.env loading in backend/README.md

## Testing
- npm run lint *(fails: Invalid option '--ext' - perhaps you meant '-c'?)*
- npx eslint src *(fails: Cannot find package '@eslint/js' imported from /workspace/WorkPro4/eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d045a413748323a28d4595804ec90f