### PR TITLE
Use Mongo ping for DB health check

### DIFF
--- a/backend/src/index.test.ts
+++ b/backend/src/index.test.ts
@@ -13,6 +13,7 @@ describe('server startup', () => {
     vi.resetModules();
     verifyDatabaseConnection.mockClear();
     delete process.env.DATABASE_URL;
+    process.env.DATABASE_URL = '';
   });
 
   afterEach(() => {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -52,11 +52,11 @@ app.get('/api/health', (_req, res) => {
 
 app.get('/health/db', async (_req, res) => {
   try {
-    // Use a lightweight SQL query to validate DB connectivity (works for SQL providers)
-    await prisma.$queryRaw`SELECT 1`;
+    // Issue a MongoDB ping command to validate connectivity
+    await prisma.$runCommandRaw({ ping: 1 });
     res.json({ ok: true });
   } catch (error) {
-    console.error('❌ Database health check failed', error);
+    console.error('❌ MongoDB health check failed', error);
     res.status(503).json({ ok: false });
   }
 });


### PR DESCRIPTION
## Summary
- replace the SQL raw query in the database health endpoint with a MongoDB `ping` command
- update the failure logging message to reflect the MongoDB connectivity check
- adjust the startup test to keep `DATABASE_URL` empty so the health check failure path is exercised consistently

## Testing
- npm --prefix backend test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d045a663ec8323bcd4bee77faa1e40