### PR TITLE
Normalize API base URL

### DIFF
--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,4 +1,24 @@
-const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
+const API_PATH = '/api';
+
+const buildApiBaseUrl = (rawUrl) => {
+  if (!rawUrl || typeof rawUrl !== 'string') {
+    return API_PATH;
+  }
+
+  const trimmedUrl = rawUrl.replace(/\/+$/, '');
+
+  if (!trimmedUrl) {
+    return API_PATH;
+  }
+
+  if (trimmedUrl.endsWith(API_PATH)) {
+    return trimmedUrl;
+  }
+
+  return `${trimmedUrl}${API_PATH}`;
+};
+
+const API_BASE_URL = buildApiBaseUrl(import.meta.env.VITE_API_URL);
 
 class ApiClient {
   constructor(baseURL) {


### PR DESCRIPTION
## Summary
- add a helper that trims trailing slashes and appends the `/api` segment when needed
- initialize the API client with the normalized base URL so direct backend requests succeed without the Vite proxy

## Testing
- pnpm lint *(fails: Invalid option '--ext' when using eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d18a4b32d483238244684a7081e80b