### PR TITLE
Add auth guard to protect layout routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { queryClient } from './lib/queryClient';
 import { ThemeProvider } from './contexts/ThemeContext';
 import { Layout } from './components/layout/Layout';
+import { ProtectedRoute } from './components/common/ProtectedRoute';
 import ErrorBoundary from './components/common/ErrorBoundary';
 
 // Import pages
@@ -27,7 +28,7 @@ export default function App() {
         <ErrorBoundary>
           <Routes>
             <Route path="/login" element={<Login />} />
-            <Route element={<Layout />}>
+            <Route element={<ProtectedRoute><Layout /></ProtectedRoute>}>
               <Route index element={<Dashboard />} />
               <Route path="assets" element={<Assets />} />
               <Route path="work-orders" element={<WorkOrders />} />

--- a/src/components/common/ProtectedRoute.tsx
+++ b/src/components/common/ProtectedRoute.tsx
@@ -1,0 +1,37 @@
+import { type ReactNode, useEffect } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../../hooks/useAuth';
+
+interface ProtectedRouteProps {
+  children: ReactNode;
+}
+
+export function ProtectedRoute({ children }: ProtectedRouteProps) {
+  const isAuthenticated = useAuth((state) => state.isAuthenticated);
+  const isLoading = useAuth((state) => state.isLoading);
+  const checkAuth = useAuth((state) => state.checkAuth);
+  const location = useLocation();
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      void checkAuth();
+    }
+  }, [checkAuth, isAuthenticated]);
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background">
+        <div
+          aria-label="Loading"
+          className="h-10 w-10 animate-spin rounded-full border-2 border-muted border-t-primary"
+        />
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace state={{ from: location }} />;
+  }
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Summary
- add a ProtectedRoute component that triggers checkAuth, shows a loading spinner, and redirects unauthenticated users to /login
- wrap the layout route in App.tsx with the new guard so nested routes require authentication

## Testing
- pnpm lint *(fails: repository eslint config requires missing @eslint/js package)*

------
https://chatgpt.com/codex/tasks/task_e_68d2b6bb6d8883238a71a8b82d127321