### PR TITLE
Fix NotFound button text color

### DIFF
--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -23,7 +23,7 @@ export default function NotFound() {
           <Link
             to="/"
             className="inline-flex items-center justify-center rounded-md px-6 py-3 text-sm font-medium shadow-sm"
-            style={{ backgroundColor: colors.primary, color: colors.primaryForeground }}
+            style={{ backgroundColor: colors.primary, color: colors.cardForeground }}
           >
             Go back home
           </Link>


### PR DESCRIPTION
## Summary
- use the card foreground theme color for the NotFound page's primary button so it references an existing token

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d3fa000db88323bd3fbd878c9223c9