### PR TITLE
Add 404 route fallback inside protected layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,7 @@ export default function App() {
               <Route path="documents" element={<Documents />} />
               <Route path="analytics" element={<Analytics />} />
               <Route path="settings" element={<Settings />} />
+              <Route path="*" element={<NotFound />} />
             </Route>
           </Routes>
         </ErrorBoundary>


### PR DESCRIPTION
## Summary
- add a catch-all route inside the protected layout to render the NotFound page for unknown paths

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3f9fdd0e8832392b6dd96ab6dfe96