### PR TITLE
chore: align backend node types for vite

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -29,7 +29,7 @@
         "@types/cors": "^2.8.13",
         "@types/express": "^4.17.17",
         "@types/jsonwebtoken": "^9.0.5",
-        "@types/node": "^18.15.0",
+        "@types/node": "^20.19.0",
         "@types/nodemailer": "^6.4.14",
         "@types/swagger-jsdoc": "^6.0.4",
         "@types/swagger-ui-express": "^4.1.6",
@@ -2616,13 +2616,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "18.19.127",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.127.tgz",
-      "integrity": "sha512-gSjxjrnKXML/yo0BO099uPixMqfpJU0TKYjpfLU7TrtA2WWDki412Np/RSTPRil1saKBhvVVKzVx/p/6p94nVA==",
+      "version": "20.19.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.14.tgz",
+      "integrity": "sha512-gqiKWld3YIkmtrrg9zDvg9jfksZCcPywXVN7IauUGhilwGV/yOyeUsvpR796m/Jye0zUzMXPKe8Ct1B79A7N5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/nodemailer": {
@@ -6609,9 +6609,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/backend/package.json
+++ b/backend/package.json
@@ -38,7 +38,7 @@
     "@types/cors": "^2.8.13",
     "@types/express": "^4.17.17",
     "@types/jsonwebtoken": "^9.0.5",
-    "@types/node": "^18.15.0",
+    "@types/node": "^20.19.0",
     "@types/nodemailer": "^6.4.14",
     "@types/swagger-jsdoc": "^6.0.4",
     "@types/swagger-ui-express": "^4.1.6",


### PR DESCRIPTION
## Summary
- bump backend @types/node dependency to ^20.19 to satisfy vite peer requirements
- update lockfile to pull undici-types 6.21 that matches the newer node type definitions

## Testing
- `npm install` *(fails: 403 Forbidden from registry in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3fdfef2488323bac4ffec92a24cd3