### PR TITLE
Fix login hash mismatch causing 401 errors

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -4,7 +4,7 @@ import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
 import rateLimit from 'express-rate-limit';
-import bcrypt from 'bcryptjs';
+import bcrypt from './lib/bcrypt';
 import { requestLogger } from './middleware/requestLogger';
 import { errorHandler } from './middleware/errorHandler';
 import { prisma, verifyDatabaseConnection } from './db';
@@ -150,7 +150,7 @@ async function ensureDemoUsers() {
     },
   });
 
-  const defaultPassword = bcrypt.hashSync('Password123', 10);
+  const defaultPassword = bcrypt.hashSync('Password123');
 
   const users = await Promise.all([
     prisma.user.create({

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import bcrypt from 'bcryptjs';
+import bcrypt from '../lib/bcrypt';
 import jwt from 'jsonwebtoken';
 import { z } from 'zod';
 import { ok, fail, asyncHandler } from '../utils/response';
@@ -25,7 +25,13 @@ router.post('/login', asyncHandler(async (req, res) => {
     },
   });
 
-  if (!user || !bcrypt.compareSync(password, user.passwordHash)) {
+  if (!user) {
+    return fail(res, 401, 'Invalid credentials');
+  }
+
+  const passwordMatches = bcrypt.compareSync(password, user.passwordHash);
+
+  if (!passwordMatches) {
     return fail(res, 401, 'Invalid credentials');
   }
 


### PR DESCRIPTION
## Summary
- update the authentication route to verify passwords with the shared bcrypt wrapper used elsewhere in the backend
- seed demo accounts with the same hashing helper so stored hashes match the login check

## Testing
- pnpm test *(fails: vitest cannot load dotenv/express while running without build tooling)*

------
https://chatgpt.com/codex/tasks/task_e_68d46c7727388323a8986fce3f545348