### PR TITLE
Improve API base URL normalization

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -66,16 +66,30 @@ export const normalizeApiBaseUrl = (value: string | undefined | null): string =>
   const trimmedValue = value?.trim() ?? '';
 
   if (!trimmedValue) {
+    if (typeof window !== 'undefined' && typeof window.location !== 'undefined') {
+      return '/api';
+    }
+
     return 'http://localhost:5010/api';
   }
 
   const withoutTrailingSlashes = trimmedValue.replace(/\/+$/u, '');
 
-  if (withoutTrailingSlashes.endsWith('/api')) {
-    return withoutTrailingSlashes;
+  if (/^https?:\/\//iu.test(withoutTrailingSlashes)) {
+    return withoutTrailingSlashes.endsWith('/api')
+      ? withoutTrailingSlashes
+      : `${withoutTrailingSlashes}/api`;
   }
 
-  return `${withoutTrailingSlashes}/api`;
+  const withLeadingSlash = withoutTrailingSlashes.startsWith('/')
+    ? withoutTrailingSlashes
+    : `/${withoutTrailingSlashes}`;
+
+  if (withLeadingSlash.endsWith('/api')) {
+    return withLeadingSlash;
+  }
+
+  return `${withLeadingSlash}/api`;
 };
 
 const API_BASE_URL = normalizeApiBaseUrl(import.meta.env.VITE_API_URL);


### PR DESCRIPTION
## Summary
- default API base URL to a same-origin /api path when running in the browser so requests stay on the current host
- extend normalization to handle relative paths consistently while preserving absolute URLs with existing /api suffixes
- add vitest coverage for browser and non-browser fallbacks plus relative path handling

## Testing
- pnpm test *(fails: backend vitest suites cannot load CJS modules in this environment)*
- pnpm vitest run src/lib/api.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d5a07c67ec8323b126339112853f56