### PR TITLE
chore: use DATABASE_URL for mongo config

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -4,8 +4,8 @@
 PORT=5010
 NODE_ENV=development
 
-# MongoDB connection (local Compass or Atlas)
-MONGO_URL=mongodb://localhost:27017/workpro4
+# MongoDB connection string (local Compass or Atlas)
+DATABASE_URL=mongodb://localhost:27017/workpro4
 
 # JWT secret for authentication
 JWT_SECRET=supersecretjwtkey_change_me

--- a/backend/src/config/mongo.ts
+++ b/backend/src/config/mongo.ts
@@ -3,9 +3,9 @@ import mongoose from '../lib/mongoose';
 mongoose.set('strictQuery', true);
 
 export async function connectMongo(): Promise<void> {
-  const url = process.env.MONGO_URL;
+  const url = process.env.DATABASE_URL ?? process.env.MONGO_URL;
   if (!url) {
-    throw new Error('Missing MONGO_URL in environment');
+    throw new Error('Missing DATABASE_URL (or legacy MONGO_URL) in environment');
   }
   await mongoose.connect(url);
   const { name, host } = mongoose.connection;


### PR DESCRIPTION
## Summary
- expose the MongoDB connection string as DATABASE_URL in the backend .env template
- load DATABASE_URL in the Mongo connection helper while still supporting the legacy MONGO_URL variable
- ensure developer docs and samples refer to DATABASE_URL going forward

## Testing
- pnpm --filter backend dev *(fails: no workspace projects match the filter in this repository)*
- pnpm dev *(fails earlier due to a missing dotenv dependency in the backend setup, before reaching the database connection)*

------
https://chatgpt.com/codex/tasks/task_e_68d6786f55e8832382e45729ed984251