### PR TITLE
Rename backend Mongo connection env variable to DATABASE_URL

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -4,8 +4,8 @@
 PORT=5010
 NODE_ENV=development
 
-# MongoDB connection (local Compass or Atlas)
-MONGO_URL=mongodb://localhost:27017/workpro4
+# Database connection string (MongoDB Compass or Atlas)
+DATABASE_URL=mongodb://localhost:27017/workpro4
 
 # JWT secret for authentication
 JWT_SECRET=supersecretjwtkey_change_me

--- a/backend/src/config/mongo.ts
+++ b/backend/src/config/mongo.ts
@@ -3,9 +3,9 @@ import mongoose from '../lib/mongoose';
 mongoose.set('strictQuery', true);
 
 export async function connectMongo(): Promise<void> {
-  const url = process.env.MONGO_URL;
+  const url = process.env.DATABASE_URL ?? process.env.MONGO_URL;
   if (!url) {
-    throw new Error('Missing MONGO_URL in environment');
+    throw new Error('Missing DATABASE_URL (or legacy MONGO_URL) in environment');
   }
   await mongoose.connect(url);
   const { name, host } = mongoose.connection;


### PR DESCRIPTION
## Summary
- rename the backend MongoDB connection variable in `.env` to `DATABASE_URL` and update the surrounding comment
- load the Mongo connection string from `DATABASE_URL` with a fallback to the legacy name inside the Mongo config

## Testing
- pnpm --filter backend dev *(fails: No projects matched the filters in "/workspace/WorkPro4")*
- pnpm --dir backend dev *(fails: missing `dotenv` package in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6786f66048323b9bea469052075a5