### PR TITLE
Rename backend Mongo connection variable to DATABASE_URL

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -4,8 +4,8 @@
 PORT=5010
 NODE_ENV=development
 
-# MongoDB connection (local Compass or Atlas)
-MONGO_URL=mongodb://localhost:27017/workpro4
+# MongoDB connection string (local Compass or Atlas)
+DATABASE_URL=mongodb://localhost:27017/workpro4
 
 # JWT secret for authentication
 JWT_SECRET=supersecretjwtkey_change_me

--- a/backend/src/config/mongo.ts
+++ b/backend/src/config/mongo.ts
@@ -3,9 +3,9 @@ import mongoose from '../lib/mongoose';
 mongoose.set('strictQuery', true);
 
 export async function connectMongo(): Promise<void> {
-  const url = process.env.MONGO_URL;
+  const url = process.env.DATABASE_URL ?? process.env.MONGO_URL;
   if (!url) {
-    throw new Error('Missing MONGO_URL in environment');
+    throw new Error('Missing DATABASE_URL in environment');
   }
   await mongoose.connect(url);
   const { name, host } = mongoose.connection;


### PR DESCRIPTION
## Summary
- rename the backend Mongo connection string in `.env` to `DATABASE_URL`
- read the Mongo connection string from `DATABASE_URL` with a fallback to the legacy `MONGO_URL`

## Testing
- `pnpm --filter backend dev` *(fails: No projects matched the filters in workspace)*
- `pnpm --dir backend dev` *(fails: runtime missing module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68d6786f6b7c832388ca155837ebd91b