### PR TITLE
refactor: read Mongo connection from DATABASE_URL

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -4,8 +4,8 @@
 PORT=5010
 NODE_ENV=development
 
-# MongoDB connection (local Compass or Atlas)
-MONGO_URL=mongodb://localhost:27017/workpro4
+# MongoDB connection string (local Compass or Atlas)
+DATABASE_URL=mongodb://localhost:27017/workpro4
 
 # JWT secret for authentication
 JWT_SECRET=supersecretjwtkey_change_me

--- a/backend/src/config/mongo.ts
+++ b/backend/src/config/mongo.ts
@@ -3,9 +3,9 @@ import mongoose from '../lib/mongoose';
 mongoose.set('strictQuery', true);
 
 export async function connectMongo(): Promise<void> {
-  const url = process.env.MONGO_URL;
+  const url = process.env.DATABASE_URL?.trim() || process.env.MONGO_URL?.trim();
   if (!url) {
-    throw new Error('Missing MONGO_URL in environment');
+    throw new Error('Missing DATABASE_URL (or legacy MONGO_URL) in environment');
   }
   await mongoose.connect(url);
   const { name, host } = mongoose.connection;


### PR DESCRIPTION
## Summary
- rename the backend MongoDB environment variable to `DATABASE_URL`
- load the connection string from `DATABASE_URL`, falling back to `MONGO_URL` for compatibility

## Testing
- pnpm dev (backend)
- pnpm db:seed

------
https://chatgpt.com/codex/tasks/task_e_68d6787015208323b0145772c001bf16