### PR TITLE
Enable Mongo replica set for local development

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -6,7 +6,7 @@ NODE_ENV=development
 
 # MongoDB connection string (local Compass or Atlas)
 
-DATABASE_URL=mongodb://localhost:27017/workpro4
+DATABASE_URL=mongodb://localhost:27017/workpro4?replicaSet=rs0
 
 # JWT secret for authentication
 JWT_SECRET=supersecretjwtkey_change_me

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,5 +1,45 @@
 # Backend Environment Configuration
 
-The backend server automatically loads environment variables from `backend/.env` on startup using `dotenv`. Any variables already
-present in the real environment will continue to take precedence, so you can override the `.env` defaults via the shell or your
-hosting platform when needed.
+The backend server automatically loads environment variables from `backend/.env` on startup using `dotenv`. Variables already present in your shell or hosting platform continue to take precedence, so you can override any default by exporting it before starting the process.
+
+## MongoDB replica set is required
+
+Prisma's MongoDB connector expects a replica set, even for local development. The default `DATABASE_URL` shipped with this repository points to `mongodb://localhost:27017/workpro4?replicaSet=rs0`. Make sure any MongoDB instance you connect to exposes the same replica-set name (or update the query string accordingly).
+
+### Recommended: Docker-based services
+
+Use the project's `docker-compose.yml` to start MongoDB (with the replica set enabled) along with the supporting services:
+
+```bash
+docker compose up -d
+```
+
+The `mongodb-init` helper container waits for MongoDB to pass its health check and then runs:
+
+```javascript
+rs.initiate({ _id: "rs0", members: [{ _id: 0, host: "mongodb:27017" }] })
+```
+
+This ensures the replica set exists before the backend boots and attempts to seed the demo tenant.
+
+### Using an existing MongoDB installation
+
+If you prefer running MongoDB directly on your machine:
+
+1. Start `mongod` with replica-set flags, e.g.
+   ```bash
+   mongod --replSet rs0 --bind_ip localhost,127.0.0.1
+   ```
+2. Open a shell and initialize the replica set once:
+   ```bash
+   mongosh --eval 'rs.initiate({ _id: "rs0", members: [{ _id: 0, host: "localhost:27017" }] })'
+   ```
+3. Update `backend/.env` so that `DATABASE_URL` references the correct host, port, database, and `replicaSet` name.
+
+After the database is ready you can start the backend with:
+
+```bash
+npm run --prefix backend dev
+```
+
+The server seeds the default tenant when the target database is empty and logs progress to the console.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,12 +3,43 @@ version: '3.8'
 services:
   mongodb:
     image: mongo:6
+    command: ["mongod", "--replSet", "rs0", "--bind_ip_all"]
     environment:
       MONGO_INITDB_DATABASE: workpro_dev
+    healthcheck:
+      test: ["CMD-SHELL", "mongosh --quiet --eval 'db.runCommand({ ping: 1 })' || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
     ports:
       - "27017:27017"
     volumes:
       - mongo_data:/data/db
+
+  mongodb-init:
+    image: mongo:6
+    depends_on:
+      mongodb:
+        condition: service_healthy
+    restart: "no"
+    entrypoint: ["bash", "-c"]
+    command: >-
+      mongosh --host mongodb:27017 --quiet --eval '
+        try {
+          const status = rs.status();
+          if (status.ok === 1) {
+            console.log("Replica set already initialized");
+          }
+        } catch (error) {
+          if (error.codeName === "NotYetInitialized" || error.code === 94) {
+            rs.initiate({ _id: "rs0", members: [{ _id: 0, host: "mongodb:27017" }] });
+            console.log("Replica set initiated");
+          } else {
+            console.error("Unexpected error while checking replica set status", error);
+            throw error;
+          }
+        }
+      '
 
   redis:
     image: redis:7-alpine


### PR DESCRIPTION
## Summary
- run MongoDB in replica-set mode via docker compose and auto-initialize the replica set
- update backend environment defaults and documentation to reference the replica set connection string
- document how to configure replica-set connectivity when using Docker or a locally installed MongoDB

## Testing
- not run (Docker is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d79286cd288323ad16aa8af0bffcd3