### PR TITLE
docs: clarify MongoDB connection defaults

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -4,9 +4,13 @@
 PORT=5010
 NODE_ENV=development
 
-# MongoDB connection string (local Compass or Atlas)
-
-DATABASE_URL=mongodb://localhost:27017/workpro4?replicaSet=rs0
+# MongoDB connection strategies
+# Option A (default): Standalone or single-node Docker MongoDB for local development.
+DATABASE_URL=mongodb://localhost:27017/workpro4?directConnection=true
+# Option B: Local replica set (e.g. Docker Compose services).
+# DATABASE_URL=mongodb://localhost:27017/workpro4?replicaSet=rs0
+# Option C: MongoDB Atlas or other managed cluster connection string.
+# DATABASE_URL=mongodb+srv://<user>:<password>@<cluster-host>/workpro4?retryWrites=true&w=majority
 
 # JWT secret for authentication
 JWT_SECRET=supersecretjwtkey_change_me

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,10 @@
-# Remove the `replicaSet` parameter if you are targeting a standalone MongoDB instance.
-# The backend will automatically enable `directConnection=true` when no replica set is configured.
-DATABASE_URL=mongodb://localhost:27017/workpro_dev?replicaSet=rs0
+# MongoDB connection strategies:
+# Option A (default): Standalone or Dockerised single-node MongoDB for local development.
+DATABASE_URL=mongodb://localhost:27017/workpro4?directConnection=true
+# Option B: Local replica set (e.g. Docker Compose services).
+# DATABASE_URL=mongodb://localhost:27017/workpro4?replicaSet=rs0
+# Option C: MongoDB Atlas or another managed cluster. Paste the SRV/standard URI from your provider.
+# DATABASE_URL=mongodb+srv://<user>:<password>@<cluster-host>/workpro4?retryWrites=true&w=majority
 REDIS_URL=redis://localhost:6379
 S3_ENDPOINT=http://localhost:9000
 S3_BUCKET=workpro-cmms


### PR DESCRIPTION
## Summary
- default backend environment templates to the standalone MongoDB URI and document replica-set and Atlas alternatives
- refresh backend and root READMEs to explain the three supported MongoDB connection strategies
- update production environment variable examples to prevent reintroducing replicaSet=rs0 by default

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7bc5f3bfc832394a1a826331248d9