### PR TITLE
Add Prisma-based seed script and update documentation

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -42,4 +42,15 @@ After the database is ready you can start the backend with:
 npm run --prefix backend dev
 ```
 
-The server seeds the default tenant when the target database is empty and logs progress to the console.
+### Seeding demo data with Prisma
+
+The backend now ships with a Prisma-based seed script that provisions a demo tenant, ensures the default admin user exists, and
+creates a sample work order linked to that account. Run it any time you need to populate a fresh database:
+
+```bash
+npm run --prefix backend db:seed
+```
+
+The script reads environment variables via `src/config/env`, reuses the shared Prisma client from `src/db`, and exits cleanly
+after disconnecting. Rerunning the seed is safe—the tenant and admin user are idempotent, and the work order is only created
+when it does not already exist.

--- a/backend/scripts/tsRegister.js
+++ b/backend/scripts/tsRegister.js
@@ -1,4 +1,6 @@
 const { readFileSync } = require('fs');
+const path = require('path');
+const Module = require('module');
 const ts = require('typescript');
 
 const compilerOptions = {
@@ -9,6 +11,12 @@ const compilerOptions = {
   resolveJsonModule: true,
   skipLibCheck: true,
 };
+
+// Allow TypeScript files to import modules from the project root using the `src/*` prefix.
+const existingNodePath = process.env.NODE_PATH ? process.env.NODE_PATH.split(path.delimiter) : [];
+const updatedNodePath = [path.resolve(__dirname, '..'), ...existingNodePath];
+process.env.NODE_PATH = Array.from(new Set(updatedNodePath)).join(path.delimiter);
+Module._initPaths();
 
 require.extensions['.ts'] = function register(module, filename) {
   const source = readFileSync(filename, 'utf8');


### PR DESCRIPTION
## Summary
- replace the Mongo-based seed script with a Prisma workflow that provisions a demo tenant, admin user, and sample work order
- update the custom TypeScript register helper to support `src/*` imports used by the seed script
- document the new Prisma seeding process in the backend README

## Testing
- not run (requires MongoDB instance)


------
https://chatgpt.com/codex/tasks/task_e_68d7bc6364a883238ccbf4fd7c32d420