### PR TITLE
Fix duplicate Asset model in Prisma schema

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -46,7 +46,7 @@ model Tenant {
 model Asset {
   id       String @id @map("_id") @default(auto()) @db.ObjectId
   tenantId String @map("tenant_id") @db.ObjectId
-  code     String
+  code     String?
   name     String
 
   tenant     Tenant     @relation(fields: [tenantId], references: [id])
@@ -76,20 +76,6 @@ model User {
   updatedAt DateTime @updatedAt
 
   @@map("users")
-}
-
-model Asset {
-  id         String      @id @map("_id") @default(auto()) @db.ObjectId
-  tenantId   String      @map("tenant_id") @db.ObjectId
-  tenant     Tenant      @relation(fields: [tenantId], references: [id])
-  code       String?
-  name       String
-  workOrders WorkOrder[]
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  @@map("assets")
 }
 
 model WorkOrder {


### PR DESCRIPTION
## Summary
- remove the duplicate `Asset` model definition from the Prisma schema
- keep the asset code optional so existing references remain valid

## Testing
- `npx prisma validate`
- `npx prisma generate`


------
https://chatgpt.com/codex/tasks/task_e_68d8df27d058832384df8715b734e30b