### PR TITLE
Refactor Prisma client initialization to use default import

### DIFF
--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -1,4 +1,8 @@
-import { PrismaClient, Prisma } from '@prisma/client';
+import PrismaPkg from '@prisma/client';
+
+const { PrismaClient } = PrismaPkg;
+type PrismaNamespace = typeof PrismaPkg.Prisma;
+type PrismaOptions = PrismaNamespace['PrismaClientOptions'];
 
 export function sanitizeDatabaseUrl(rawUrl: string | undefined) {
   if (!rawUrl) {
@@ -29,7 +33,7 @@ export function sanitizeDatabaseUrl(rawUrl: string | undefined) {
   return trimmedUrl;
 }
 
-function getPrismaClientOptions(): Prisma.PrismaClientOptions | undefined {
+function getPrismaClientOptions(): PrismaOptions | undefined {
   const databaseUrl = sanitizeDatabaseUrl(process.env.DATABASE_URL);
 
   if (!databaseUrl) {


### PR DESCRIPTION
## Summary
- switch `backend/src/db.ts` to use the default Prisma package import and derive the client/types from it
- preserve the existing sanitize helper, singleton wiring, and shutdown hooks while using the new Prisma-derived types

## Testing
- `npm run lint --prefix backend` *(fails: Invalid option '--ext' when using eslint.config.js flat config)*
- `npm run build --prefix backend` *(fails: existing TypeScript errors in backend/src/index.ts unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d8df2961f4832389fa8372060d964d