### PR TITLE
Update seed script to locate tenant by name

### DIFF
--- a/backend/src/scripts/seed.ts
+++ b/backend/src/scripts/seed.ts
@@ -7,13 +7,12 @@ async function main(): Promise<void> {
   await prisma.$connect();
 
   const tenantName = 'Demo Tenant';
-  const tenantSlug = 'demo-tenant';
   const adminEmail = 'admin@demo.com';
   const passwordHash = await bcrypt.hash('Admin@123', 10);
 
   const tenant =
-    (await prisma.tenant.findFirst({ where: { slug: tenantSlug } })) ??
-    (await prisma.tenant.create({ data: { name: tenantName, slug: tenantSlug } }));
+    (await prisma.tenant.findUnique({ where: { name: tenantName } })) ??
+    (await prisma.tenant.create({ data: { name: tenantName } }));
 
   const adminUser = await prisma.user.upsert({
     where: { email: adminEmail },


### PR DESCRIPTION
## Summary
- update the seed script to look up or create the demo tenant by its name instead of a slug so it aligns with the Prisma schema

## Testing
- npm run --prefix backend db:seed *(fails: MongoDB connection refused in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8eba922388323b98674c193405878