### PR TITLE
Fix auth login response handling

### DIFF
--- a/frontend/src/hooks/useAuth.jsx
+++ b/frontend/src/hooks/useAuth.jsx
@@ -28,11 +28,18 @@ export function AuthProvider({ children }) {
 
     try {
       const res = await api.post('/api/auth/login', { email, password });
-      localStorage.setItem(TOKEN_KEY, res.token);
-      localStorage.setItem(USER_KEY, JSON.stringify(res.user ?? null));
-      setToken(res.token);
-      setUser(res.user ?? null);
-      return { ok: true, user: res.user };
+      const { token: nextToken, user: nextUser } = res?.data ?? {};
+
+      if (!nextToken) {
+        throw new Error('Missing token in login response');
+      }
+
+      localStorage.setItem(TOKEN_KEY, nextToken);
+      localStorage.setItem(USER_KEY, JSON.stringify(nextUser ?? null));
+      setToken(nextToken);
+      setUser(nextUser ?? null);
+
+      return { ok: true, user: nextUser };
     } catch (err) {
       if (err?.status === 401) {
         setError('Invalid email or password.');


### PR DESCRIPTION
## Summary
- update the login flow to read the token and user from the response data payload
- persist the retrieved credentials before returning a successful login and guard against missing tokens

## Testing
- pnpm --filter frontend build *(fails: tsconfig.json:10:25 - error TS6046: Argument for '--moduleResolution' option must be: 'node', 'classic', 'node16', 'nodenext'.)*

------
https://chatgpt.com/codex/tasks/task_e_68d8ebab03648323885e814f1eba611e