### PR TITLE
Simplify backend MongoDB env configuration

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -4,13 +4,8 @@
 PORT=5010
 NODE_ENV=development
 
-# MongoDB connection strategies
-# Option A (default): Standalone or single-node Docker MongoDB for local development.
-DATABASE_URL=mongodb://localhost:27017/workpro?directConnection=true
-# Option B: Local replica set (e.g. Docker Compose services).
-# DATABASE_URL=mongodb://localhost:27017/workpro4?replicaSet=rs0
-# Option C: MongoDB Atlas or other managed cluster connection string.
-# DATABASE_URL=mongodb+srv://<user>:<password>@<cluster-host>/workpro4?retryWrites=true&w=majority
+# MongoDB connection
+DATABASE_URL="mongodb://127.0.0.1:27017/workpro4?directConnection=true"
 
 # JWT secret for authentication
 JWT_SECRET=supersecretjwtkey_change_me


### PR DESCRIPTION
## Summary
- replace the MongoDB connection section in backend/.env with the specified single URL entry

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8fba965388323971d9bf92da8c8c6