### PR TITLE
Seed default tenant and admin during startup

### DIFF
--- a/backend/src/index.test.ts
+++ b/backend/src/index.test.ts
@@ -2,18 +2,87 @@ import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 
 const originalDatabaseUrl = process.env.DATABASE_URL;
 const verifyDatabaseConnection = vi.fn();
+const ensureTenantNoTxn = vi.fn();
+const ensureAdminNoTxn = vi.fn();
+const dotenvConfig = vi.fn();
+const expressJson = vi.fn();
+const expressUrlencoded = vi.fn();
+const expressApp = {
+  use: vi.fn(),
+  get: vi.fn(),
+  listen: vi.fn(),
+};
+const corsMiddleware = vi.fn();
+const corsFactory = vi.fn(() => corsMiddleware);
+const helmetMiddleware = vi.fn();
+const helmetFactory = vi.fn(() => helmetMiddleware);
+const rateLimitMiddleware = vi.fn();
+const rateLimitFactory = vi.fn(() => rateLimitMiddleware);
+
+vi.mock('dotenv', () => ({
+  default: { config: dotenvConfig },
+  config: dotenvConfig,
+}));
+
+vi.mock('express', () => {
+  const express = () => expressApp;
+  express.json = () => expressJson;
+  express.urlencoded = () => expressUrlencoded;
+  return { default: express };
+});
+
+vi.mock('cors', () => ({
+  default: corsFactory,
+}));
+
+vi.mock('helmet', () => ({
+  default: helmetFactory,
+}));
+
+vi.mock('express-rate-limit', () => ({
+  default: rateLimitFactory,
+}));
 
 vi.mock('./db', () => ({
   prisma: {},
   verifyDatabaseConnection,
 }));
 
+vi.mock('./lib/seedHelpers', () => ({
+  ensureTenantNoTxn,
+  ensureAdminNoTxn,
+}));
+
+vi.mock('./routes/auth', () => ({ default: {} }));
+vi.mock('./routes/summary', () => ({ default: {} }));
+vi.mock('./routes/simpleWorkOrders', () => ({ default: {} }));
+vi.mock('./routes/assets', () => ({ default: {} }));
+vi.mock('./routes/parts', () => ({ default: {} }));
+vi.mock('./routes/vendors', () => ({ default: {} }));
+vi.mock('./routes/search', () => ({ default: {} }));
+
 describe('server startup', () => {
   beforeEach(() => {
     vi.resetModules();
     verifyDatabaseConnection.mockClear();
+    ensureTenantNoTxn.mockReset();
+    ensureAdminNoTxn.mockReset();
+    expressApp.use.mockReset();
+    expressApp.get.mockReset();
+    expressApp.listen.mockReset();
+    expressJson.mockReset();
+    expressUrlencoded.mockReset();
+    corsFactory.mockReset();
+    corsMiddleware.mockReset();
+    helmetFactory.mockReset();
+    helmetMiddleware.mockReset();
+    rateLimitFactory.mockReset();
+    rateLimitMiddleware.mockReset();
+    ensureTenantNoTxn.mockResolvedValue({ tenant: { id: 'tenant-id' }, created: true });
+    ensureAdminNoTxn.mockResolvedValue({ admin: { id: 'admin-id' }, created: true });
     delete process.env.DATABASE_URL;
     process.env.DATABASE_URL = '';
+    process.env.SEED_SAMPLE_WORK_ORDER = 'false';
   });
 
   afterEach(() => {
@@ -22,6 +91,7 @@ describe('server startup', () => {
     } else {
       process.env.DATABASE_URL = originalDatabaseUrl;
     }
+    delete process.env.SEED_SAMPLE_WORK_ORDER;
   });
 
   it('exits when DATABASE_URL is missing', async () => {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -9,6 +9,7 @@ import { requestLogger } from './middleware/requestLogger';
 import { errorHandler } from './middleware/errorHandler';
 import { prisma, verifyDatabaseConnection } from './db';
 import { ensureJwtSecrets } from './config/auth';
+import { ensureAdminNoTxn, ensureTenantNoTxn } from './lib/seedHelpers';
 
 // Routes
 import authRoutes from './routes/auth';
@@ -107,7 +108,7 @@ async function start() {
 
   try {
     await verifyDatabaseConnection();
-    console.log('🗄️ Connected to database');
+    console.log('Connected to database');
   } catch (error) {
     console.error('❌ Failed to connect to database', error);
 
@@ -121,13 +122,13 @@ async function start() {
     return;
   }
 
-  await ensureDemoUsers();
+  await seedDefaultsNoTxn();
 
   app.listen(PORT, () => {
-    console.log(`🚀 Backend server running on port ${PORT}`);
-    console.log(`🩺 Health check: http://localhost:${PORT}/api/health`);
-    console.log(`🗄️ DB health: http://localhost:${PORT}/health/db`);
-    console.log(`🔐 API base: http://localhost:${PORT}/api`);
+    console.log(`API listening on http://localhost:${PORT}`);
+    console.log(`Health check ready at http://localhost:${PORT}/api/health`);
+    console.log(`DB health at http://localhost:${PORT}/health/db`);
+    console.log(`API base at http://localhost:${PORT}/api`);
   });
 }
 
@@ -135,6 +136,60 @@ start().catch((error) => {
   console.error('❌ Failed to start server', error);
   process.exit(1);
 });
+
+async function seedDefaultsNoTxn(): Promise<void> {
+  const tenantName = process.env.DEFAULT_TENANT_NAME?.trim() || 'Demo Tenant';
+  const adminEmail = process.env.DEFAULT_ADMIN_EMAIL?.trim() || 'admin@demo.com';
+  const adminName = process.env.DEFAULT_ADMIN_NAME?.trim() || 'Admin';
+  const adminPassword = process.env.DEFAULT_ADMIN_PASSWORD || 'Admin@123';
+  const seedWorkOrder = process.env.SEED_SAMPLE_WORK_ORDER !== 'false';
+  const workOrderTitle = process.env.SAMPLE_WORK_ORDER_TITLE?.trim() || 'Demo Work Order';
+  const workOrderDescription =
+    process.env.SAMPLE_WORK_ORDER_DESCRIPTION?.trim() || 'Inspect the demo asset and confirm it is running.';
+
+  const { tenant } = await ensureTenantNoTxn(prisma, tenantName);
+  const passwordHash = await bcrypt.hash(adminPassword, 10);
+  const { admin } = await ensureAdminNoTxn({
+    prisma,
+    tenantId: tenant.id,
+    email: adminEmail,
+    name: adminName,
+    passwordHash,
+    roles: ['admin'],
+  });
+
+  console.log('[seed] tenant+admin ready (non-transactional)');
+
+  if (!seedWorkOrder) {
+    return;
+  }
+
+  const existingWorkOrder = await prisma.workOrder.findFirst({
+    where: {
+      tenantId: tenant.id,
+      title: workOrderTitle,
+    },
+  });
+
+  if (existingWorkOrder) {
+    console.log('[seed] sample work order already exists:', existingWorkOrder.id);
+    return;
+  }
+
+  const workOrder = await prisma.workOrder.create({
+    data: {
+      tenantId: tenant.id,
+      title: workOrderTitle,
+      description: workOrderDescription,
+      priority: 'medium',
+      status: 'requested',
+      assignees: [admin.id],
+      createdBy: admin.id,
+    },
+  });
+
+  console.log('[seed] sample work order created:', workOrder.id);
+}
 
 function isReplicaSetPrimaryError(error: unknown): boolean {
   if (!error || typeof error !== 'object') {

--- a/backend/src/lib/seedHelpers.ts
+++ b/backend/src/lib/seedHelpers.ts
@@ -1,0 +1,54 @@
+import type { PrismaClient, Tenant, User } from '@prisma/client';
+
+export interface EnsureTenantResult {
+  tenant: Tenant;
+  created: boolean;
+}
+
+export async function ensureTenantNoTxn(prisma: PrismaClient, tenantName: string): Promise<EnsureTenantResult> {
+  const existing = await prisma.tenant.findUnique({ where: { name: tenantName } });
+  if (existing) {
+    return { tenant: existing, created: false };
+  }
+
+  const tenant = await prisma.tenant.create({ data: { name: tenantName } });
+  return { tenant, created: true };
+}
+
+export interface EnsureAdminOptions {
+  prisma: PrismaClient;
+  tenantId: string;
+  email: string;
+  name: string;
+  passwordHash: string;
+  roles: string[];
+}
+
+export interface EnsureAdminResult {
+  admin: User;
+  created: boolean;
+}
+
+export async function ensureAdminNoTxn(options: EnsureAdminOptions): Promise<EnsureAdminResult> {
+  const { prisma, tenantId, email, name, passwordHash, roles } = options;
+
+  const admin = await prisma.user.upsert({
+    where: { email },
+    update: {
+      tenantId,
+      name,
+      roles,
+      passwordHash,
+    },
+    create: {
+      tenantId,
+      email,
+      name,
+      roles,
+      passwordHash,
+    },
+  });
+
+  const created = admin.createdAt.getTime() === admin.updatedAt.getTime();
+  return { admin, created };
+}


### PR DESCRIPTION
## Summary
- add reusable seed helpers for ensuring a tenant and admin user without transactions
- seed defaults during server startup with optional sample work order creation and updated logging
- expand server startup test mocks to cover new dependencies and seeding helpers

## Testing
- npm test --prefix backend -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d8fbaafbc88323917a72efcd6d1d37