### PR TITLE
Inline demo tenant slug generation

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -220,12 +220,11 @@ function isReplicaSetPrimaryError(error: unknown): boolean {
 
 async function ensureDemoUsers() {
   const tenantName = 'Demo Tenant';
-  const tenantSlug = 'demo-tenant';
 
   const tenant = await prisma.tenant.upsert({
     where: { name: tenantName },
-    update: { slug: tenantSlug },
-    create: { name: tenantName, slug: tenantSlug },
+    update: { slug: tenantName.toLowerCase().replace(/\s+/g, '-') },
+    create: { name: tenantName, slug: tenantName.toLowerCase().replace(/\s+/g, '-') },
   });
 
   const defaultPassword = bcrypt.hashSync('Password123');


### PR DESCRIPTION
## Summary
- derive the demo tenant slug inline during the seed upsert

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d903b9404c83239a885e727f2b14f7