### PR TITLE
Update demo user seeding to use roles array

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -245,14 +245,14 @@ async function ensureDemoUsers() {
       update: {
         passwordHash: defaultPassword,
         name: demoUser.name,
-        role: demoUser.role,
+        roles: [demoUser.role],
         tenantId: tenant.id,
       },
       create: {
         email: demoUser.email,
         passwordHash: defaultPassword,
         name: demoUser.name,
-        role: demoUser.role,
+        roles: [demoUser.role],
         tenantId: tenant.id,
       },
     });


### PR DESCRIPTION
## Summary
- update the demo user seeding logic to assign role values through the roles array
- confirm other seed helpers already rely on the roles array field

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d903bb75ac83239116df41da2b34cb