### PR TITLE
Use FRONTEND_ORIGIN for backend CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ pnpm --filter backend db:seed
 
 The backend reads its MongoDB connection string from the `DATABASE_URL` value in `backend/.env`. Copying the example file seeds it with the standalone URI (`mongodb://localhost:27017/workpro4?directConnection=true`), which works for single-node development without replica sets. Adjust the URI if you're using the replica-set or managed-cluster strategies described above.
 
+Set `FRONTEND_ORIGIN` in `backend/.env` to the fully qualified origin (scheme + host + port) that should be allowed by CORS in production. When the variable is omitted the backend falls back to the local development origin (`http://localhost:5173`).
+
 4. **Start development servers:**
 ```bash
 pnpm dev:all

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -16,5 +16,7 @@ MAILDEV_HOST=localhost
 MAILDEV_PORT=1025
 NODE_ENV=development
 PORT=5010
+# Frontend origin allowed for CORS in production
+FRONTEND_ORIGIN=http://localhost:5173
 # Ensure the frontend targets Express' `/api/*` namespace.
 VITE_API_URL=http://localhost:5010/api

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -29,13 +29,17 @@ dotenv.config({ path: envPath });
 
 const app = express();
 const PORT = Number(process.env.PORT) || 5010;
+const isProduction = process.env.NODE_ENV === 'production';
+const configuredFrontendOrigin = process.env.FRONTEND_ORIGIN?.trim() ?? process.env.FRONTEND_URL?.trim();
 
 // Security middleware
 app.use(helmet());
-app.use(cors({
-  origin: process.env.NODE_ENV === 'production' ? process.env.FRONTEND_URL : 'http://localhost:5173',
-  credentials: true,
-}));
+app.use(
+  cors({
+    origin: isProduction ? configuredFrontendOrigin || 'http://localhost:5173' : 'http://localhost:5173',
+    credentials: true,
+  }),
+);
 
 // Rate limiting
 const limiter = rateLimit({


### PR DESCRIPTION
## Summary
- update the Express CORS configuration to prefer the FRONTEND_ORIGIN environment variable while keeping the localhost fallback for development
- document the FRONTEND_ORIGIN variable in the backend environment templates and README so deployers set the expected origin

## Testing
- not run (MongoDB service unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d97bee22908323bf2f45c28454dd0c