### PR TITLE
Load backend env config before database initialization

### DIFF
--- a/backend/src/bootstrapEnv.ts
+++ b/backend/src/bootstrapEnv.ts
@@ -1,0 +1,6 @@
+import path from 'path';
+import dotenv from 'dotenv';
+
+const envPath = path.resolve(__dirname, '../.env');
+
+dotenv.config({ path: envPath });

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,5 +1,4 @@
-import path from 'path';
-import dotenv from 'dotenv';
+import './bootstrapEnv';
 import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
@@ -20,12 +19,6 @@ import partRoutes from './routes/parts';
 import vendorRoutes from './routes/vendors';
 import searchRoutes from './routes/search';
 
-
-const envPath = path.resolve(__dirname, '../.env');
-
-// Load environment variables from backend/.env while still allowing real environment
-// variables to take precedence when they are already defined.
-dotenv.config({ path: envPath });
 
 const app = express();
 const PORT = Number(process.env.PORT) || 5010;


### PR DESCRIPTION
## Summary
- load backend environment variables through a bootstrap module so the database client sees `DATABASE_URL`

## Testing
- pnpm --dir backend lint *(fails: Invalid option '--ext' - eslint.config.js no longer supports --ext)*

------
https://chatgpt.com/codex/tasks/task_e_68d985e92b508323acc25d65bf1c292c