### PR TITLE
Handle Prisma clients without runCommand ping

### DIFF
--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -47,8 +47,14 @@ if (process.env.NODE_ENV !== "production") {
 export async function verifyDatabaseConnection(): Promise<void> {
   try {
     await prisma.$connect();
-    await prisma.$runCommandRaw({ ping: 1 });
-    console.log("[db] ping ok");
+    if (typeof (prisma as { $runCommandRaw?: unknown }).$runCommandRaw === "function") {
+      await (prisma as { $runCommandRaw: (command: Record<string, unknown>) => Promise<unknown> }).$runCommandRaw({
+        ping: 1,
+      });
+      console.log("[db] ping ok");
+    } else {
+      console.log("[db] connected (ping skipped: $runCommandRaw unavailable)");
+    }
   } catch (err: any) {
     const hint =
       "Check DATABASE_URL in /backend/.env. For local Mongo, try:\n" +


### PR DESCRIPTION
## Summary
- guard the database ping so Prisma clients without $runCommandRaw still succeed after connecting
- expand the database unit tests to cover Prisma clients that omit the Mongo ping helper

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d9d223511083238d422fb7bdd50b8c