### PR TITLE
Handle tenant timestamp backfill on P2032

### DIFF
--- a/backend/src/lib/__tests__/seedHelpers.test.ts
+++ b/backend/src/lib/__tests__/seedHelpers.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@prisma/client', () => {
+  class PrismaClientKnownRequestError extends Error {
+    code: string;
+    clientVersion: string;
+
+    constructor(message: string, options: { code: string; clientVersion: string }) {
+      super(message);
+      this.code = options.code;
+      this.clientVersion = options.clientVersion;
+    }
+  }
+
+  return {
+    Prisma: { PrismaClientKnownRequestError },
+    PrismaClient: class {},
+  };
+});
+
+import { Prisma } from '@prisma/client';
+import type { PrismaClient } from '@prisma/client';
+
+import { ensureTenantNoTxn } from '../seedHelpers';
+
+describe('ensureTenantNoTxn', () => {
+  it('recovers from P2032 error by backfilling timestamps and returns the tenant', async () => {
+    const tenantName = 'Acme Corp';
+    const slug = tenantName.toLowerCase().replace(/\s+/g, '-');
+    const tenant = { id: 'tenant-1', name: tenantName, slug };
+
+    const recoveryError = Object.assign(new Error('missing timestamps'), {
+      code: 'P2032',
+      clientVersion: 'test',
+    });
+    Object.setPrototypeOf(recoveryError, Prisma.PrismaClientKnownRequestError.prototype);
+
+    const findUnique = vi
+      .fn()
+      .mockRejectedValueOnce(recoveryError as Prisma.PrismaClientKnownRequestError)
+      .mockResolvedValueOnce(tenant);
+    const updateMany = vi.fn().mockResolvedValue({ count: 1 });
+
+    const prisma = {
+      tenant: {
+        findUnique,
+        update: vi.fn(),
+        updateMany,
+        create: vi.fn(),
+      },
+    } as unknown as PrismaClient;
+
+    const result = await ensureTenantNoTxn(prisma, tenantName);
+
+    expect(findUnique).toHaveBeenCalledTimes(2);
+    expect(updateMany).toHaveBeenCalledTimes(1);
+
+    const updateArgs = updateMany.mock.calls[0][0];
+    expect(updateArgs.where.slug).toBe(slug);
+    expect(updateArgs.data.createdAt).toBeInstanceOf(Date);
+    expect(updateArgs.data.updatedAt).toBeInstanceOf(Date);
+
+    expect(result).toEqual({ tenant, created: false });
+  });
+});


### PR DESCRIPTION
## Summary
- retry tenant lookup after handling Prisma P2032 errors by backfilling timestamps
- add a Vitest that stubs Prisma to exercise the recovery path and ensure the tenant is returned

## Testing
- pnpm test -- --run backend/src/lib/__tests__/seedHelpers.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68da05528d308323afa09ba89543548c