### PR TITLE
Use raw Mongo update for tenant timestamp backfill

### DIFF
--- a/backend/src/lib/seedHelpers.ts
+++ b/backend/src/lib/seedHelpers.ts
@@ -6,6 +6,44 @@ export interface EnsureTenantResult {
   created: boolean;
 }
 
+async function backfillTenantTimestamps(
+  prisma: PrismaClient,
+  now: Date,
+  slug?: string,
+): Promise<void> {
+  const missingTimestampFilter = {
+    $or: [
+      { createdAt: { $exists: false } },
+      { createdAt: { $type: 10 } },
+      { updatedAt: { $exists: false } },
+      { updatedAt: { $type: 10 } },
+    ],
+  } satisfies Record<string, unknown>;
+
+  const query = {
+    ...(slug ? { slug } : {}),
+    ...missingTimestampFilter,
+  } satisfies Record<string, unknown>;
+
+  const updateCommand = {
+    update: 'tenants',
+    updates: [
+      {
+        q: query,
+        u: {
+          $set: {
+            createdAt: now,
+            updatedAt: now,
+          },
+        },
+        multi: true,
+      },
+    ],
+  } satisfies Record<string, unknown>;
+
+  await prisma.$runCommandRaw(updateCommand as Prisma.InputJsonObject);
+}
+
 export async function ensureTenantNoTxn(prisma: PrismaClient, tenantName: string): Promise<EnsureTenantResult> {
   const slug = tenantName.toLowerCase().replace(/\s+/g, '-');
   let existing: Tenant | null = null;
@@ -16,16 +54,7 @@ export async function ensureTenantNoTxn(prisma: PrismaClient, tenantName: string
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2032') {
       const now = new Date();
 
-      await prisma.tenant.updateMany({
-        where: {
-          slug,
-          OR: [{ createdAt: null }, { updatedAt: null }],
-        },
-        data: {
-          createdAt: now,
-          updatedAt: now,
-        },
-      });
+      await backfillTenantTimestamps(prisma, now, slug);
 
       existing = await prisma.tenant.findUnique({ where: { slug } });
     } else {
@@ -67,15 +96,7 @@ export async function ensureTenantNoTxn(prisma: PrismaClient, tenantName: string
         ],
       });
 
-      await prisma.tenant.updateMany({
-        where: {
-          OR: [{ createdAt: null }, { updatedAt: null }],
-        },
-        data: {
-          createdAt: now,
-          updatedAt: now,
-        },
-      });
+      await backfillTenantTimestamps(prisma, now);
 
       const tenant = await prisma.tenant.findUnique({ where: { slug } });
 


### PR DESCRIPTION
## Summary
- replace tenant timestamp backfill updateMany calls with a raw Mongo update command that checks for missing values
- share the new backfill helper between the P2032 recovery path and P2031 fallback handling
- update the seed helper tests to assert the raw update command usage

## Testing
- npm run --prefix backend test -- --run --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68da08fefd488323840a8b87d9c3d513