### PR TITLE
Log seeded tenant and admin ids

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -170,6 +170,7 @@ async function seedDefaultsNoTxn(): Promise<void> {
   });
 
   console.log('[seed] tenant+admin ready (non-transactional)');
+  console.log('[seed] ids:', { tenantId: tenant.id, adminId: admin.id });
 
   if (!seedWorkOrder) {
     return;


### PR DESCRIPTION
## Summary
- log the seeded tenant and admin identifiers during non-transactional seeding for better visibility

## Testing
- npm run --prefix backend dev *(fails: MongoDB instance not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db5d27102c83238bd8564ea8779015