### PR TITLE
Normalize seeded IDs for default work order seeding

### DIFF
--- a/backend/src/lib/ids.ts
+++ b/backend/src/lib/ids.ts
@@ -1,0 +1,37 @@
+import { ObjectId } from 'mongodb';
+
+const HEX_24_REGEX = /^[a-f\d]{24}$/i;
+
+export function normalizeToObjectIdString(input: unknown): string {
+  if (typeof input === 'string') {
+    const trimmed = input.trim();
+
+    if (HEX_24_REGEX.test(trimmed)) {
+      return trimmed.toLowerCase();
+    }
+
+    throw new TypeError(`Invalid ObjectId string: "${trimmed}"`);
+  }
+
+  if (input instanceof ObjectId) {
+    return input.toHexString();
+  }
+
+  if (input && typeof input === 'object') {
+    const candidate = input as { toHexString?: () => unknown; _id?: unknown };
+
+    if (typeof candidate.toHexString === 'function') {
+      const hex = candidate.toHexString();
+
+      if (typeof hex === 'string') {
+        return normalizeToObjectIdString(hex);
+      }
+    }
+
+    if ('_id' in candidate) {
+      return normalizeToObjectIdString(candidate._id);
+    }
+  }
+
+  throw new TypeError('Unsupported ObjectId input');
+}


### PR DESCRIPTION
## Summary
- add a normalization helper that converts various ObjectId inputs into 24-character hex strings
- normalize tenant and admin ids before logging and seeding the default work order so Prisma only receives strings

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db608475688323a922b076fc01b96e