### PR TITLE
Normalize seed helper ObjectId handling

### DIFF
--- a/backend/src/lib/normalizeObjectId.ts
+++ b/backend/src/lib/normalizeObjectId.ts
@@ -1,0 +1,29 @@
+import { ObjectId } from 'mongodb';
+
+type HexStringConvertible = { toHexString(): string };
+
+export type NormalizableObjectId = ObjectId | string | HexStringConvertible;
+
+function hasToHexString(value: unknown): value is HexStringConvertible {
+  return Boolean(value && typeof (value as HexStringConvertible).toHexString === 'function');
+}
+
+export function normalizeObjectId(value: NormalizableObjectId): string {
+  if (value instanceof ObjectId) {
+    return value.toHexString();
+  }
+
+  if (hasToHexString(value)) {
+    return value.toHexString();
+  }
+
+  if (typeof value === 'string') {
+    if (!ObjectId.isValid(value)) {
+      throw new Error('Invalid ObjectId string provided');
+    }
+
+    return new ObjectId(value).toHexString();
+  }
+
+  throw new Error('Unable to normalize provided ObjectId value');
+}

--- a/backend/src/lib/seedHelpers.test.ts
+++ b/backend/src/lib/seedHelpers.test.ts
@@ -14,8 +14,12 @@ vi.mock('mongodb', () => ({
       return this.value;
     }
 
+    toHexString(): string {
+      return this.value;
+    }
+
     static isValid(value: string): boolean {
-      return Boolean(value);
+      return typeof value === 'string' && value.length === 24;
     }
   },
 }));
@@ -59,7 +63,11 @@ describe('ensureTenantNoTxn', () => {
 
   it('creates a tenant with a slug when none exists', async () => {
     findUnique.mockResolvedValue(null);
-    const createdTenant = { id: 'tenant-1', name: 'Demo Tenant', slug: 'demo-tenant' };
+    const createdTenant = {
+      id: '507f1f77bcf86cd799439011',
+      name: 'Demo Tenant',
+      slug: 'demo-tenant',
+    };
     create.mockResolvedValue(createdTenant);
 
     const result = await ensureTenantNoTxn(prisma, 'Demo Tenant');
@@ -75,7 +83,11 @@ describe('ensureTenantNoTxn', () => {
   });
 
   it('returns the existing tenant when it already has a slug', async () => {
-    const existingTenant = { id: 'tenant-1', name: 'Demo Tenant', slug: 'demo-tenant' };
+    const existingTenant = {
+      id: '507f1f77bcf86cd799439011',
+      name: 'Demo Tenant',
+      slug: 'demo-tenant',
+    };
     findUnique.mockResolvedValue(existingTenant);
 
     const result = await ensureTenantNoTxn(prisma, 'Demo Tenant');
@@ -86,7 +98,7 @@ describe('ensureTenantNoTxn', () => {
   });
 
   it('adds a slug to an existing tenant when missing', async () => {
-    const existingTenant = { id: 'tenant-1', name: 'Demo Tenant', slug: '' };
+    const existingTenant = { id: '507f1f77bcf86cd799439011', name: 'Demo Tenant', slug: '' };
     const updatedTenant = { ...existingTenant, slug: 'demo-tenant' };
     findUnique.mockResolvedValue(existingTenant);
     update.mockResolvedValue(updatedTenant);
@@ -104,7 +116,11 @@ describe('ensureTenantNoTxn', () => {
 
   it('falls back to a raw insert when create fails with P2031', async () => {
     const { Prisma } = await import('@prisma/client');
-    const fallbackTenant = { id: 'tenant-1', name: 'Demo Tenant', slug: 'demo-tenant' };
+    const fallbackTenant = {
+      id: '507f1f77bcf86cd799439011',
+      name: 'Demo Tenant',
+      slug: 'demo-tenant',
+    };
 
     findUnique.mockResolvedValueOnce(null).mockResolvedValueOnce(fallbackTenant);
     create.mockRejectedValueOnce(
@@ -163,7 +179,11 @@ describe('ensureTenantNoTxn', () => {
 
   it('backfills timestamps on tenants with null values before refetching', async () => {
     const { Prisma } = await import('@prisma/client');
-    const fallbackTenant = { id: 'tenant-1', name: 'Demo Tenant', slug: 'demo-tenant' };
+    const fallbackTenant = {
+      id: '507f1f77bcf86cd799439011',
+      name: 'Demo Tenant',
+      slug: 'demo-tenant',
+    };
 
     let timestampsBackfilled = false;
 


### PR DESCRIPTION
## Summary
- add a normalizeObjectId helper to standardize ObjectId values as hex strings
- run seed helper flows through the normalizer before returning tenant and user records
- refresh seed helper unit tests to mock ObjectIds with 24-character hex strings

## Testing
- pnpm --dir backend test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68db60847dac8323bd17531d54c2de87