### PR TITLE
Improve ObjectId normalization and seed logging

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -9,7 +9,7 @@ import { errorHandler } from './middleware/errorHandler';
 import { prisma, verifyDatabaseConnection } from './db';
 import { ensureJwtSecrets } from './config/auth';
 import { ensureAdminNoTxn, ensureTenantNoTxn } from './lib/seedHelpers';
-import { normalizeToObjectIdString } from './lib/ids';
+import { normalizeObjectId } from './lib/normalizeObjectId';
 
 // Routes
 import authRoutes from './routes/auth';
@@ -161,7 +161,7 @@ async function seedDefaultsNoTxn(): Promise<void> {
     return;
   }
 
-  const tenantId = normalizeToObjectIdString(tenant.id);
+  const tenantId = normalizeObjectId(tenant.id);
   const passwordHash = await bcrypt.hash(adminPassword, 10);
   const { admin } = await ensureAdminNoTxn({
     prisma,
@@ -178,9 +178,9 @@ async function seedDefaultsNoTxn(): Promise<void> {
     return;
   }
 
-  const adminId = normalizeToObjectIdString(admin.id);
+  const adminId = normalizeObjectId(admin.id);
 
-  console.log('[seed] ids:', { tenantId, adminId });
+  console.log('[seed] normalized ids:', { tenantId, adminId });
 
   if (!seedWorkOrder) {
     return;

--- a/backend/src/lib/normalizeObjectId.ts
+++ b/backend/src/lib/normalizeObjectId.ts
@@ -1,29 +1,59 @@
 import { ObjectId } from 'mongodb';
 
-type HexStringConvertible = { toHexString(): string };
+type HexStringConvertible = { toHexString(): unknown };
+type WithIdProperty = { id?: unknown; _id?: unknown };
 
-export type NormalizableObjectId = ObjectId | string | HexStringConvertible;
+export type NormalizableObjectId = ObjectId | string | HexStringConvertible | WithIdProperty;
+
+const HEX_24_REGEX = /^[a-f\d]{24}$/i;
 
 function hasToHexString(value: unknown): value is HexStringConvertible {
   return Boolean(value && typeof (value as HexStringConvertible).toHexString === 'function');
 }
 
-export function normalizeObjectId(value: NormalizableObjectId): string {
-  if (value instanceof ObjectId) {
-    return value.toHexString();
+function isWithIdProperty(value: unknown): value is WithIdProperty {
+  return Boolean(value && typeof value === 'object' && ('id' in (value as WithIdProperty) || '_id' in (value as WithIdProperty)));
+}
+
+function validateAndFormatHex(hex: string): string {
+  const trimmed = hex.trim();
+
+  if (!HEX_24_REGEX.test(trimmed)) {
+    throw new TypeError(`Invalid ObjectId string provided: "${trimmed}"`);
   }
 
-  if (hasToHexString(value)) {
-    return value.toHexString();
+  return trimmed.toLowerCase();
+}
+
+export function normalizeObjectId(value: NormalizableObjectId): string {
+  if (value instanceof ObjectId) {
+    return validateAndFormatHex(value.toHexString());
   }
 
   if (typeof value === 'string') {
-    if (!ObjectId.isValid(value)) {
-      throw new Error('Invalid ObjectId string provided');
-    }
-
-    return new ObjectId(value).toHexString();
+    return validateAndFormatHex(value);
   }
 
-  throw new Error('Unable to normalize provided ObjectId value');
+  if (hasToHexString(value)) {
+    const result = value.toHexString();
+
+    if (typeof result === 'string') {
+      return validateAndFormatHex(result);
+    }
+  }
+
+  if (isWithIdProperty(value)) {
+    if (value.id != null) {
+      return normalizeObjectId(value.id as NormalizableObjectId);
+    }
+
+    if (value._id != null) {
+      return normalizeObjectId(value._id as NormalizableObjectId);
+    }
+  }
+
+  const typeDescription = value === null ? 'null' : typeof value;
+  console.error('[normalizeObjectId] Unable to normalize value of type:', typeDescription, value);
+
+  throw new TypeError('Unable to normalize provided ObjectId value');
 }


### PR DESCRIPTION
## Summary
- extend the ObjectId normalizer to trim strings, recurse on id/_id holders, and log unsupported inputs
- consume the improved helper during startup seeding so tenant/admin IDs are normalized before logging and work-order creation

## Testing
- npm run dev --prefix backend *(fails: MongoDB not reachable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db68d65eec83239f37d7fc507e5bf7