### PR TITLE
Improve ObjectId normalization resilience and logging

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -161,7 +161,7 @@ async function seedDefaultsNoTxn(): Promise<void> {
     return;
   }
 
-  const tenantId = normalizeObjectId(tenant.id);
+  const tenantId = normalizeObjectId(tenant.id, 'seedDefaultsNoTxn.tenant.id');
   const passwordHash = await bcrypt.hash(adminPassword, 10);
   const { admin } = await ensureAdminNoTxn({
     prisma,
@@ -178,7 +178,7 @@ async function seedDefaultsNoTxn(): Promise<void> {
     return;
   }
 
-  const adminId = normalizeObjectId(admin.id);
+  const adminId = normalizeObjectId(admin.id, 'seedDefaultsNoTxn.admin.id');
 
   console.log('[seed] normalized ids:', { tenantId, adminId });
 

--- a/backend/src/lib/normalizeObjectId.ts
+++ b/backend/src/lib/normalizeObjectId.ts
@@ -2,58 +2,123 @@ import { ObjectId } from 'mongodb';
 
 type HexStringConvertible = { toHexString(): unknown };
 type WithIdProperty = { id?: unknown; _id?: unknown };
+type ExtendedJsonObjectId = { $oid?: unknown };
 
-export type NormalizableObjectId = ObjectId | string | HexStringConvertible | WithIdProperty;
+export type NormalizableObjectId =
+  | ObjectId
+  | string
+  | HexStringConvertible
+  | WithIdProperty
+  | ExtendedJsonObjectId;
 
 const HEX_24_REGEX = /^[a-f\d]{24}$/i;
+const MAX_PREVIEW_STRING_LENGTH = 60;
 
 function hasToHexString(value: unknown): value is HexStringConvertible {
   return Boolean(value && typeof (value as HexStringConvertible).toHexString === 'function');
 }
 
-function isWithIdProperty(value: unknown): value is WithIdProperty {
-  return Boolean(value && typeof value === 'object' && ('id' in (value as WithIdProperty) || '_id' in (value as WithIdProperty)));
+function createPreview(value: unknown): string {
+  const seen = new WeakSet<object>();
+
+  try {
+    const result = JSON.stringify(
+      value,
+      (_key, serializedValue) => {
+        if (typeof serializedValue === 'string' && serializedValue.length > MAX_PREVIEW_STRING_LENGTH) {
+          return `${serializedValue.slice(0, MAX_PREVIEW_STRING_LENGTH - 1)}…`;
+        }
+
+        if (typeof serializedValue === 'object' && serializedValue !== null) {
+          if (seen.has(serializedValue)) {
+            return '[Circular]';
+          }
+
+          seen.add(serializedValue);
+        }
+
+        return serializedValue;
+      },
+    );
+
+    if (typeof result === 'string') {
+      return result;
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown serialization error';
+    return `[Unserializable value: ${message}]`;
+  }
+
+  return String(value);
 }
 
-function validateAndFormatHex(hex: string): string {
+function failToNormalize(label: string, value: unknown, reason: string): never {
+  const displayLabel = label || 'ObjectId';
+  const preview = createPreview(value);
+
+  console.error(
+    `[normalizeObjectId] Failed to normalize "${displayLabel}": ${reason}. Value preview: ${preview}`,
+  );
+
+  throw new TypeError(`Unable to normalize ObjectId for "${displayLabel}".`);
+}
+
+function validateAndFormatHex(hex: string, label: string): string {
   const trimmed = hex.trim();
 
   if (!HEX_24_REGEX.test(trimmed)) {
-    throw new TypeError(`Invalid ObjectId string provided: "${trimmed}"`);
+    failToNormalize(label, hex, 'Expected a 24-character hexadecimal string');
   }
 
   return trimmed.toLowerCase();
 }
 
-export function normalizeObjectId(value: NormalizableObjectId): string {
-  if (value instanceof ObjectId) {
-    return validateAndFormatHex(value.toHexString());
-  }
+export function normalizeObjectId(value: NormalizableObjectId, label = 'ObjectId'): string {
+  const visited = new Set<unknown>();
 
-  if (typeof value === 'string') {
-    return validateAndFormatHex(value);
-  }
-
-  if (hasToHexString(value)) {
-    const result = value.toHexString();
-
-    if (typeof result === 'string') {
-      return validateAndFormatHex(result);
-    }
-  }
-
-  if (isWithIdProperty(value)) {
-    if (value.id != null) {
-      return normalizeObjectId(value.id as NormalizableObjectId);
+  const normalize = (input: unknown, currentLabel: string): string => {
+    if (input instanceof ObjectId) {
+      return validateAndFormatHex(input.toHexString(), currentLabel);
     }
 
-    if (value._id != null) {
-      return normalizeObjectId(value._id as NormalizableObjectId);
+    if (typeof input === 'string') {
+      return validateAndFormatHex(input, currentLabel);
     }
-  }
 
-  const typeDescription = value === null ? 'null' : typeof value;
-  console.error('[normalizeObjectId] Unable to normalize value of type:', typeDescription, value);
+    if (hasToHexString(input)) {
+      const result = input.toHexString();
 
-  throw new TypeError('Unable to normalize provided ObjectId value');
+      if (typeof result === 'string') {
+        return validateAndFormatHex(result, currentLabel);
+      }
+
+      failToNormalize(currentLabel, result, 'toHexString() did not return a string');
+    }
+
+    if (input && typeof input === 'object') {
+      if (visited.has(input)) {
+        failToNormalize(currentLabel, input, 'Encountered a circular reference');
+      }
+
+      visited.add(input);
+
+      const candidate = input as WithIdProperty & ExtendedJsonObjectId;
+
+      if (candidate.$oid != null) {
+        return normalize(candidate.$oid, `${currentLabel}.$oid`);
+      }
+
+      if (candidate.id != null) {
+        return normalize(candidate.id, `${currentLabel}.id`);
+      }
+
+      if (candidate._id != null) {
+        return normalize(candidate._id, `${currentLabel}._id`);
+      }
+    }
+
+    failToNormalize(currentLabel, input, 'Value could not be interpreted as an ObjectId');
+  };
+
+  return normalize(value, label);
 }

--- a/backend/src/lib/seedHelpers.ts
+++ b/backend/src/lib/seedHelpers.ts
@@ -218,15 +218,15 @@ function normalizeRoles(roles: string[]): string[] {
 function normalizeTenant(tenant: Tenant): Tenant {
   return {
     ...tenant,
-    id: normalizeObjectId(tenant.id),
+    id: normalizeObjectId(tenant.id, 'tenant.id'),
   };
 }
 
 function normalizeUser(user: User): User {
   return {
     ...user,
-    id: normalizeObjectId(user.id),
-    tenantId: normalizeObjectId(user.tenantId),
+    id: normalizeObjectId(user.id, 'user.id'),
+    tenantId: normalizeObjectId(user.tenantId, 'user.tenantId'),
   };
 }
 
@@ -237,7 +237,10 @@ function ensureValidTenantId(tenantId: string): { tenantObjectId: ObjectId; tena
 
   const tenantObjectId = new ObjectId(tenantId);
 
-  return { tenantObjectId, tenantId: normalizeObjectId(tenantObjectId) };
+  return {
+    tenantObjectId,
+    tenantId: normalizeObjectId(tenantObjectId, 'ensureValidTenantId.tenantObjectId'),
+  };
 }
 
 async function applyRoles(
@@ -319,8 +322,8 @@ async function upsertUserRaw(
   }
 
   const admin: User = {
-    id: normalizeObjectId(document._id),
-    tenantId: normalizeObjectId(document.tenant_id),
+    id: normalizeObjectId(document._id, 'MongoUserDocument._id'),
+    tenantId: normalizeObjectId(document.tenant_id, 'MongoUserDocument.tenant_id'),
     email: normalizedEmail,
     passwordHash: document.password_hash,
     name: document.name,


### PR DESCRIPTION
## Summary
- extend `normalizeObjectId` to support extended inputs, add preview logging, and accept optional labels for clearer errors
- update backend seeding utilities and startup flow to pass descriptive labels to the normalizer

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db6c20503c8323bba6163f24ee6ea2