### PR TITLE
Improve seed normalization logging

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -161,7 +161,9 @@ async function seedDefaultsNoTxn(): Promise<void> {
     return;
   }
 
-  const tenantId = normalizeObjectId(tenant.id);
+  console.dir({ tenantRaw: tenant?.id, adminRaw: undefined }, { depth: 5 });
+
+  const tenantId = normalizeObjectId(tenant?.id, 'tenant.id');
   const passwordHash = await bcrypt.hash(adminPassword, 10);
   const { admin } = await ensureAdminNoTxn({
     prisma,
@@ -178,9 +180,11 @@ async function seedDefaultsNoTxn(): Promise<void> {
     return;
   }
 
-  const adminId = normalizeObjectId(admin.id);
+  console.dir({ tenantRaw: tenant?.id, adminRaw: admin?.id }, { depth: 5 });
 
-  console.log('[seed] normalized ids:', { tenantId, adminId });
+  const adminId = normalizeObjectId(admin?.id, 'admin.id');
+
+  console.log('[seed] ids:', { tenantId, adminId });
 
   if (!seedWorkOrder) {
     return;


### PR DESCRIPTION
## Summary
- log the tenant and admin identifiers before normalization to capture their original shapes
- pass descriptive labels into `normalizeObjectId` for clearer error reporting
- align the seed success log message with the expected `[seed] ids` format

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db6c207b7483238aa9a86d3483e3d2