### PR TITLE
Fix tenant relation for admin seed helper

### DIFF
--- a/backend/src/lib/seedHelpers.ts
+++ b/backend/src/lib/seedHelpers.ts
@@ -390,7 +390,7 @@ export async function ensureAdminNoTxn(options: EnsureAdminOptions): Promise<Ens
     try {
       const admin = await prisma.user.create({
         data: {
-          tenantId: normalizedTenantId,
+          tenant: { connect: { id: normalizedTenantId } },
           email: normalizedEmail,
           name,
           roles: normalizedRoles,
@@ -454,7 +454,7 @@ export async function ensureAdminNoTxn(options: EnsureAdminOptions): Promise<Ens
   const admin = await prisma.user.update({
     where: { id: existing.id },
     data: {
-      tenantId: normalizedTenantId,
+      tenant: { connect: { id: normalizedTenantId } },
       email: normalizedEmail,
       name,
       roles: normalizedRoles,


### PR DESCRIPTION
## Summary
- switch ensureAdminNoTxn to connect the tenant relation when creating or updating users

## Testing
- pnpm --dir backend db:seed *(fails: Cannot find module '.prisma/client/default')*

------
https://chatgpt.com/codex/tasks/task_e_68db72af1e1c8323aa2368526c1bef42