### PR TITLE
Fix role updates to use Prisma set operations

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -275,7 +275,7 @@ async function ensureDemoUsers() {
       update: {
         passwordHash: defaultPassword,
         name: demoUser.name,
-        roles: demoUser.roles,
+        roles: { set: demoUser.roles },
         tenantId: tenant.id,
       },
       create: {

--- a/backend/src/lib/seedHelpers.ts
+++ b/backend/src/lib/seedHelpers.ts
@@ -457,7 +457,7 @@ export async function ensureAdminNoTxn(options: EnsureAdminOptions): Promise<Ens
       tenant: { connect: { id: normalizedTenantId } },
       email: normalizedEmail,
       name,
-      roles: normalizedRoles,
+      roles: { set: normalizedRoles },
 
       passwordHash,
     },

--- a/backend/src/scripts/seed.ts
+++ b/backend/src/scripts/seed.ts
@@ -175,7 +175,7 @@ async function ensureAdminNoTxn(params: EnsureAdminParams): Promise<EnsureAdminR
     where: { email },
     data: {
       name,
-      roles,
+      roles: { set: roles },
       passwordHash,
       tenantId,
     },


### PR DESCRIPTION
## Summary
- ensure all user update paths assign roles using Prisma's `set` notation
- align demo user seeding logic with Prisma's relation update requirements

## Testing
- npm run --prefix backend db:generate
- npm run --prefix backend db:seed *(fails: MongoDB not running in container, confirms no Prisma validation error)*
- npm run --prefix backend dev *(fails: MongoDB not running in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dba8da0ae48323b4a92cdfdd2614c2