### PR TITLE
Use Prisma scalar list update for admin roles

### DIFF
--- a/backend/src/lib/seedHelpers.ts
+++ b/backend/src/lib/seedHelpers.ts
@@ -457,7 +457,7 @@ export async function ensureAdminNoTxn(options: EnsureAdminOptions): Promise<Ens
       tenant: { connect: { id: normalizedTenantId } },
       email: normalizedEmail,
       name,
-      roles: normalizedRoles,
+      roles: { set: normalizedRoles },
 
       passwordHash,
     },


### PR DESCRIPTION
## Summary
- update the admin update path to use Prisma's scalar-list `set` syntax for roles

## Testing
- pnpm db:generate
- pnpm db:seed *(fails: PrismaClientKnownRequestError due to MongoDB connection refused in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc3d2138148323a2227888689a5fd8