### PR TITLE
Refine seeding helpers to store single role

### DIFF
--- a/backend/src/index.test.ts
+++ b/backend/src/index.test.ts
@@ -1,5 +1,27 @@
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 
+vi.mock('mongodb', () => ({
+  ObjectId: class {
+    value: string;
+
+    constructor(value: string) {
+      this.value = value;
+    }
+
+    toString(): string {
+      return this.value;
+    }
+
+    toHexString(): string {
+      return this.value;
+    }
+
+    static isValid(value: string): boolean {
+      return typeof value === 'string' && value.length === 24;
+    }
+  },
+}));
+
 const originalDatabaseUrl = process.env.DATABASE_URL;
 const verifyDatabaseConnection = vi.fn();
 const ensureTenantNoTxn = vi.fn();

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -172,7 +172,7 @@ async function seedDefaultsNoTxn(): Promise<void> {
     email: adminEmail,
     name: adminName,
     passwordHash,
-    roles: ['admin'],
+    role: 'admin',
   });
 
   console.log('[seed] tenant+admin ready (non-transactional)');

--- a/backend/src/lib/__tests__/seedHelpers.test.ts
+++ b/backend/src/lib/__tests__/seedHelpers.test.ts
@@ -112,7 +112,7 @@ describe('ensureAdminNoTxn', () => {
     const email = 'Admin@example.com';
     const normalizedEmail = email.toLowerCase();
     const name = 'Admin';
-    const roles = ['ADMIN'];
+    const role = 'ADMIN';
     const passwordHash = 'hash';
 
     const existingUser = {
@@ -120,14 +120,14 @@ describe('ensureAdminNoTxn', () => {
       tenantId,
       email,
       name: 'Old Name',
-      roles: ['USER'],
+      role: 'USER',
       passwordHash: 'old-hash',
     } satisfies Record<string, unknown>;
 
     const updatedUser = {
       ...existingUser,
       name,
-      roles,
+      role,
       passwordHash,
     } satisfies Record<string, unknown>;
 
@@ -146,7 +146,7 @@ describe('ensureAdminNoTxn', () => {
       email: normalizedEmail,
       password_hash: passwordHash,
       name,
-      role: roles[0],
+      role,
       createdAt: now,
       updatedAt: now,
     };
@@ -171,7 +171,7 @@ describe('ensureAdminNoTxn', () => {
       email,
       name,
       passwordHash,
-      roles,
+      role,
     });
 
     expect(findUnique).toHaveBeenCalledTimes(1);
@@ -190,13 +190,17 @@ describe('ensureAdminNoTxn', () => {
     expect(upsertCommand.upsert).toBe(true);
     expect(upsertCommand.new).toBe(true);
 
+    const updateSet = upsertCommand.update.$set;
+    expect(updateSet.role).toBe(role);
+    expect(updateSet.roles).toBeUndefined();
+
     expect(result.created).toBe(false);
     expect(result.admin.id).toBe('507f1f77bcf86cd799439012');
     expect(result.admin.tenantId).toBe(tenantId);
     expect(result.admin.email).toBe(normalizedEmail);
     expect(result.admin.passwordHash).toBe(passwordHash);
     expect(result.admin.name).toBe(name);
-    expect(result.admin.role).toBe(roles[0]);
+    expect(result.admin.role).toBe(role);
     expect(result.admin.createdAt).toBeInstanceOf(Date);
     expect(result.admin.updatedAt).toBeInstanceOf(Date);
   });


### PR DESCRIPTION
## Summary
- update the seeding helpers to work with a single role string, normalize tenant ids, and simplify the raw upsert fallback
- adjust backend entry points and scripts to use the new helper signature and ensure tests provide a MongoDB mock
- refresh seed helper tests to exercise the streamlined API and role expectations

## Testing
- pnpm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68dc4088868c8323b04cfc3e6c8359db