### PR TITLE
Update User role definition in Prisma schema

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -28,7 +28,7 @@ model User {
   email        String @unique
   passwordHash String @map("password_hash")
   name         String
-  roles        String[] @default([])
+  role         String @default("user")
 
   tenant            Tenant      @relation(fields: [tenantId], references: [id])
   createdWorkOrders WorkOrder[] @relation("CreatedBy")


### PR DESCRIPTION
## Summary
- replace the User model roles array with a single role field defaulting to "user" to match the existing migration

## Testing
- npx prisma generate --schema backend/prisma/schema.prisma

------
https://chatgpt.com/codex/tasks/task_e_68dca8826bc88323a3ca226cb95117a3