### PR TITLE
Improve admin seeding update flow

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -165,13 +165,12 @@ async function seedDefaultsNoTxn(): Promise<void> {
 
   const tenantId = normalizeObjectId(tenant?.id, 'tenant.id');
 
-  const passwordHash = await bcrypt.hash(adminPassword, 10);
   const { admin } = await ensureAdminNoTxn({
     prisma,
     tenantId,
     email: adminEmail,
     name: adminName,
-    passwordHash,
+    password: adminPassword,
     role: 'admin',
   });
 


### PR DESCRIPTION
## Summary
- short-circuit `ensureAdminNoTxn` when an existing admin already matches the expected tenant, email, role, and password
- hash the admin password only when changes are required and avoid updating relational fields during admin updates
- expand the seed helper and server startup tests to cover the new behavior and the existing-admin startup scenario

## Testing
- npm run --prefix backend test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68dcb56287ac8323bb090f9e3dd5476c