### PR TITLE
feat: add work order validator and schema updates

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -32,7 +32,7 @@ model User {
 
   tenant            Tenant      @relation(fields: [tenantId], references: [id])
   createdWorkOrders WorkOrder[] @relation("CreatedBy")
-  assignedWorkOrders WorkOrder[] @relation("Assignee")
+  assignedWorkOrders WorkOrder[] @relation("AssignedTo")
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -79,21 +79,19 @@ model WorkOrder {
   priority      WorkOrderPriority @default(medium)
   status        WorkOrderStatus   @default(requested)
   assetId       String?           @map("asset_id") @db.ObjectId
-  lineName      String?           @map("line_name")
-  stationNumber String?           @map("station_number")
-  assigneeId    String?           @map("assignee_id") @db.ObjectId
-  assignees     String[]          @default([])
-  checklists    Json?
+  assignedTo    String?           @map("assigned_to") @db.ObjectId
+  category      String?
+  dueDate       DateTime?         @map("due_date")
+  attachments   String[]          @default([])
   partsUsed     Json?             @map("parts_used")
   signatures    Json?
   timeSpentMin  Int?              @map("time_spent_min")
-  photos        String[]          @default([])
   failureCode   String?           @map("failure_code")
   pmTaskId      String?           @map("pm_task_id") @db.ObjectId
   createdBy     String            @map("created_by") @db.ObjectId
 
   tenant        Tenant   @relation(fields: [tenantId], references: [id])
-  assignee      User?    @relation("Assignee", fields: [assigneeId], references: [id])
+  assignedToUser User?    @relation("AssignedTo", fields: [assignedTo], references: [id])
   createdByUser User     @relation("CreatedBy", fields: [createdBy], references: [id])
   asset         Asset?   @relation(fields: [assetId], references: [id])
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -212,7 +212,7 @@ async function seedDefaultsNoTxn(): Promise<void> {
         description: workOrderDescription,
         priority: 'medium',
         status: 'requested',
-        assignees: [adminId],
+        assignedTo: adminId,
         createdBy: adminId,
       },
     });

--- a/backend/src/routes/simpleWorkOrders.test.ts
+++ b/backend/src/routes/simpleWorkOrders.test.ts
@@ -119,7 +119,7 @@ describe('simpleWorkOrders POST /', () => {
       data: null,
       error: {
         code: 400,
-        message: 'Invalid assetId',
+        message: 'Value must be a valid ObjectId string',
         details: undefined,
       },
     });
@@ -144,13 +144,14 @@ describe('simpleWorkOrders POST /', () => {
       priority: 'medium',
       assetId: 'aaaaaaaaaaaaaaaaaaaaaaaa',
       asset: null,
-      lineName: null,
-      stationNumber: null,
-      assignees: [],
+      assignedTo: null,
+      assignedToUser: null,
+      category: null,
+      attachments: [],
+      dueDate: null,
       createdByUser: { id: 'user-1', name: 'Requester' },
       createdAt: now,
       updatedAt: now,
-      checklists: [],
       timeSpentMin: null,
     });
 
@@ -165,6 +166,12 @@ describe('simpleWorkOrders POST /', () => {
       expect.objectContaining({
         data: expect.objectContaining({
           assetId: 'aaaaaaaaaaaaaaaaaaaaaaaa',
+          attachments: [],
+          assignedTo: null,
+          category: undefined,
+          dueDate: undefined,
+          priority: 'medium',
+          status: 'requested',
         }),
       }),
     );
@@ -174,6 +181,10 @@ describe('simpleWorkOrders POST /', () => {
       data: expect.objectContaining({
         id: 'order-1',
         assetId: 'aaaaaaaaaaaaaaaaaaaaaaaa',
+        attachments: [],
+        assignedTo: null,
+        category: null,
+        dueDate: null,
       }),
       error: null,
     });

--- a/backend/src/routes/simpleWorkOrders.ts
+++ b/backend/src/routes/simpleWorkOrders.ts
@@ -1,97 +1,22 @@
 import { Router } from 'express';
 import { Prisma } from '@prisma/client';
-import { z } from 'zod';
 import { prisma } from '../db';
-import { normalizeToObjectIdString } from '../lib/ids';
+import { createWorkOrderValidator } from '../validators/workOrderValidators';
 import { asyncHandler, fail, ok } from '../utils/response';
 
 const router = Router();
 
-const workOrderCreateSchema = z.object({
-  title: z.string().min(1, 'Title is required'),
-  description: z.string().trim().optional(),
-  priority: z
-    .enum(['low', 'medium', 'high', 'urgent'])
-    .optional()
-    .default('medium'),
-  status: z
-    .enum(['requested', 'assigned', 'in_progress', 'completed', 'cancelled'])
-    .optional()
-    .default('requested'),
-  assetId: z
-    .string()
-    .trim()
-    .superRefine((value, ctx) => {
-      try {
-        normalizeToObjectIdString(value);
-      } catch (error) {
-        if (error instanceof TypeError) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            message: 'Invalid assetId',
-          });
-          return;
-        }
-
-        throw error;
-      }
-    })
-    .transform((value) => normalizeToObjectIdString(value))
-    .optional(),
-  lineName: z.string().optional(),
-  stationNumber: z.string().optional(),
-  assignees: z.array(z.string()).optional(),
-  checklists: z
-    .array(
-      z.object({
-        text: z.string().trim().min(1),
-        note: z.string().trim().optional(),
-      }),
-    )
-    .optional(),
-});
+const workOrderCreateSchema = createWorkOrderValidator;
 
 type WorkOrderWithRelations = Prisma.WorkOrderGetPayload<{
   include: {
     asset: { select: { id: true; code: true; name: true } };
     createdByUser: { select: { id: true; name: true } };
+    assignedToUser: { select: { id: true; name: true } };
   };
 }>;
 
 function mapWorkOrder(workOrder: WorkOrderWithRelations) {
-  const rawChecklists = Array.isArray(workOrder.checklists)
-    ? (workOrder.checklists as Prisma.JsonArray)
-    : [];
-
-  type NormalizedChecklist = {
-    text: string;
-    note?: string;
-    done: boolean;
-    completedAt?: string;
-  };
-
-  const checklists = rawChecklists.reduce<NormalizedChecklist[]>((acc, item) => {
-    if (!item || typeof item !== 'object') {
-      return acc;
-    }
-
-    const record = item as Record<string, unknown>;
-
-    const text = typeof record.text === 'string' ? record.text : '';
-    const note = typeof record.note === 'string' ? record.note : undefined;
-    const done = 'done' in record ? Boolean(record.done) : false;
-    const completedAt = typeof record.completedAt === 'string' ? record.completedAt : undefined;
-
-    if (!text) {
-      return acc;
-    }
-
-    acc.push({ text, note, done, completedAt });
-    return acc;
-  }, []);
-
-  const assignees = Array.isArray(workOrder.assignees) ? workOrder.assignees.filter((id) => id) : [];
-
   return {
     id: workOrder.id,
     title: workOrder.title,
@@ -101,18 +26,17 @@ function mapWorkOrder(workOrder: WorkOrderWithRelations) {
     assetId: workOrder.assetId ?? null,
     assetName: workOrder.asset?.name ?? null,
     assetCode: workOrder.asset?.code ?? null,
-    lineName: workOrder.lineName ?? null,
-    stationNumber: workOrder.stationNumber ?? null,
-    assignees,
-    assigneeNames: assignees,
+    assignedTo: workOrder.assignedTo ?? null,
+    assignedToName: workOrder.assignedToUser?.name ?? null,
+    category: workOrder.category ?? null,
+    attachments: Array.isArray(workOrder.attachments) ? workOrder.attachments : [],
     requestedById: workOrder.createdByUser?.id ?? null,
     requestedByName: workOrder.createdByUser?.name ?? 'System',
     createdAt: workOrder.createdAt.toISOString(),
     updatedAt: workOrder.updatedAt.toISOString(),
     completedAt: workOrder.status === 'completed' ? workOrder.updatedAt.toISOString() : null,
-    dueDate: null,
+    dueDate: workOrder.dueDate ? workOrder.dueDate.toISOString() : null,
     actualHours: workOrder.timeSpentMin ? workOrder.timeSpentMin / 60 : null,
-    checklists,
   };
 }
 
@@ -137,7 +61,7 @@ router.get(
       return fail(res, 500, 'No default user found');
     }
 
-    const { status, priority, assignee, from, to, q } = req.query;
+    const { status, priority, assignee, from, to, q, category } = req.query;
 
     const where: Prisma.WorkOrderWhereInput = {};
 
@@ -158,7 +82,11 @@ router.get(
     }
 
     if (typeof assignee === 'string' && assignee) {
-      where.assignees = { has: assignee };
+      where.assignedTo = assignee;
+    }
+
+    if (typeof category === 'string' && category.trim().length > 0) {
+      where.category = category.trim();
     }
 
     const createdAt: { gte?: Date; lte?: Date } = {};
@@ -187,8 +115,7 @@ router.get(
         { title: { contains: search, mode: 'insensitive' } },
         { description: { contains: search, mode: 'insensitive' } },
         { assetId: { contains: search, mode: 'insensitive' } },
-        { lineName: { contains: search, mode: 'insensitive' } },
-        { stationNumber: { contains: search, mode: 'insensitive' } },
+        { category: { contains: search, mode: 'insensitive' } },
         { id: { contains: search, mode: 'insensitive' } },
       ];
     }
@@ -198,6 +125,7 @@ router.get(
       include: {
         asset: { select: { id: true, code: true, name: true } },
         createdByUser: { select: { id: true, name: true } },
+        assignedToUser: { select: { id: true, name: true } },
       },
       orderBy: { createdAt: 'desc' },
     });
@@ -228,30 +156,24 @@ router.post(
       return fail(res, 500, 'No default user found to assign work orders');
     }
 
-    const normalizedAssignees = payload.assignees?.filter((value) => value.trim().length > 0) ?? [];
-    const normalizedChecklists = payload.checklists?.filter((item) => item.text.trim().length > 0) ?? [];
-
     const workOrder = await prisma.workOrder.create({
       data: {
-        title: payload.title.trim(),
-        description: payload.description?.trim() || undefined,
-        priority: payload.priority,
-        status: payload.status,
+        title: payload.title,
+        description: payload.description,
+        priority: payload.priority ?? 'medium',
+        status: payload.status ?? 'requested',
         tenantId: defaultUser.tenantId,
         createdBy: defaultUser.id,
         assetId: payload.assetId ?? undefined,
-        lineName: payload.lineName?.trim() || undefined,
-        stationNumber: payload.stationNumber?.trim() || undefined,
-        assignees: normalizedAssignees,
-        checklists: normalizedChecklists.map((item) => ({
-          text: item.text.trim(),
-          note: item.note?.trim(),
-          done: false,
-        })),
+        assignedTo: payload.assignedTo ?? null,
+        category: payload.category ?? undefined,
+        dueDate: payload.dueDate ? new Date(payload.dueDate) : undefined,
+        attachments: payload.attachments ?? [],
       },
       include: {
         asset: { select: { id: true, code: true, name: true } },
         createdByUser: { select: { id: true, name: true } },
+        assignedToUser: { select: { id: true, name: true } },
       },
     });
 

--- a/backend/src/routes/workOrders.ts
+++ b/backend/src/routes/workOrders.ts
@@ -1,32 +1,53 @@
 import { Router } from 'express';
 import { z } from 'zod';
+import { Prisma, WorkOrderStatus } from '@prisma/client';
 import { ok, fail, asyncHandler } from '../utils/response';
 import { authenticateToken, AuthRequest } from '../middleware/auth';
 import { prisma } from '../db';
-import { Prisma, WorkOrderStatus } from '@prisma/client';
+import {
+  createWorkOrderValidator,
+  objectIdSchema,
+  priorityEnum,
+  statusEnum,
+} from '../validators/workOrderValidators';
 
 const router = Router();
 
 router.use(authenticateToken);
 
-const statusEnum = z.enum(['requested', 'assigned', 'in_progress', 'completed', 'cancelled']);
-
-const createWorkOrderSchema = z.object({
-  title: z.string().min(1),
-  description: z.string().optional(),
-  status: statusEnum.optional(),
-  assigneeId: z.string().optional(),
-});
-
 const updateWorkOrderSchema = z.object({
-  title: z.string().min(1).optional(),
-  description: z.string().optional(),
+  title: z.string().trim().min(3).max(120).optional(),
+  description: z.string().trim().max(4000).optional(),
   status: statusEnum.optional(),
-  assigneeId: z.string().nullable().optional(),
-});
+  priority: priorityEnum.optional(),
+  assetId: objectIdSchema.optional().nullable(),
+  assignedTo: z.union([objectIdSchema, z.null()]).optional(),
+  category: z.string().trim().max(120).optional().nullable(),
+  dueDate: z
+    .union([
+      z.string().min(1),
+      z.null(),
+    ])
+    .optional()
+    .superRefine((value, ctx) => {
+      if (value === undefined || value === null) {
+        return;
+      }
+
+      const parsed = new Date(value);
+
+      if (Number.isNaN(parsed.getTime())) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'dueDate must be an ISO 8601 date string',
+        });
+      }
+    }),
+  attachments: z.array(objectIdSchema).optional(),
+}).strict();
 
 const workOrderInclude = {
-  assignee: {
+  assignedToUser: {
     select: {
       id: true,
       name: true,
@@ -39,7 +60,25 @@ type WorkOrderWithRelations = Prisma.WorkOrderGetPayload<{ include: typeof workO
 
 function serializeWorkOrder(workOrder: WorkOrderWithRelations) {
   return {
-    ...workOrder,
+    id: workOrder.id,
+    tenantId: workOrder.tenantId,
+    title: workOrder.title,
+    description: workOrder.description ?? null,
+    priority: workOrder.priority,
+    status: workOrder.status,
+    assetId: workOrder.assetId ?? null,
+    assignedTo: workOrder.assignedTo ?? null,
+    assignedToUser: workOrder.assignedToUser
+      ? {
+          id: workOrder.assignedToUser.id,
+          name: workOrder.assignedToUser.name,
+          email: workOrder.assignedToUser.email,
+        }
+      : null,
+    category: workOrder.category ?? null,
+    dueDate: workOrder.dueDate ? workOrder.dueDate.toISOString() : null,
+    attachments: Array.isArray(workOrder.attachments) ? workOrder.attachments : [],
+    createdBy: workOrder.createdBy,
     createdAt: workOrder.createdAt.toISOString(),
     updatedAt: workOrder.updatedAt.toISOString(),
   };
@@ -74,7 +113,7 @@ router.get('/:id', asyncHandler(async (req: AuthRequest, res) => {
 
 // POST /work-orders
 router.post('/', asyncHandler(async (req: AuthRequest, res) => {
-  const data = createWorkOrderSchema.parse(req.body);
+  const data = createWorkOrderValidator.parse(req.body);
 
   if (!req.user) {
     return fail(res, 401, 'Authentication required');
@@ -85,10 +124,14 @@ router.post('/', asyncHandler(async (req: AuthRequest, res) => {
       title: data.title,
       description: data.description,
       status: (data.status ?? 'requested') as WorkOrderStatus,
-      assigneeId: data.assigneeId,
+      priority: data.priority ?? 'medium',
+      assetId: data.assetId ?? undefined,
+      assignedTo: data.assignedTo ?? null,
+      category: data.category ?? undefined,
+      dueDate: data.dueDate ? new Date(data.dueDate) : undefined,
+      attachments: data.attachments ?? [],
       tenantId: req.user.tenantId,
       createdBy: req.user.id,
-      assignees: data.assigneeId ? [data.assigneeId] : [],
 
     },
     include: workOrderInclude,
@@ -108,14 +151,42 @@ router.put('/:id', asyncHandler(async (req: AuthRequest, res) => {
     return fail(res, 404, 'Work order not found');
   }
 
-  const updateData: { [key: string]: unknown } = {
-    ...(data.title !== undefined ? { title: data.title } : {}),
-    ...(data.description !== undefined ? { description: data.description } : {}),
-    ...(data.status !== undefined ? { status: data.status as WorkOrderStatus } : {}),
-  };
+  const updateData: { [key: string]: unknown } = {};
 
-  if ('assigneeId' in data) {
-    updateData.assigneeId = data.assigneeId ?? null;
+  if (data.title !== undefined) {
+    updateData.title = data.title;
+  }
+
+  if (data.description !== undefined) {
+    updateData.description = data.description || null;
+  }
+
+  if (data.status !== undefined) {
+    updateData.status = data.status as WorkOrderStatus;
+  }
+
+  if (data.priority !== undefined) {
+    updateData.priority = data.priority;
+  }
+
+  if ('assetId' in data) {
+    updateData.assetId = data.assetId ?? null;
+  }
+
+  if ('assignedTo' in data) {
+    updateData.assignedTo = data.assignedTo ?? null;
+  }
+
+  if ('category' in data) {
+    updateData.category = data.category && data.category.length > 0 ? data.category : null;
+  }
+
+  if ('dueDate' in data) {
+    updateData.dueDate = data.dueDate ? new Date(data.dueDate) : null;
+  }
+
+  if (data.attachments !== undefined) {
+    updateData.attachments = data.attachments;
   }
 
   const workOrder = await prisma.workOrder.update({

--- a/backend/src/scripts/seed.ts
+++ b/backend/src/scripts/seed.ts
@@ -49,7 +49,7 @@ async function main(): Promise<void> {
         description: 'Inspect the demo asset and confirm it is running.',
         priority: 'medium',
         status: 'requested',
-        assignees: [adminUser.id],
+        assignedTo: adminUser.id,
         createdBy: adminUser.id,
       },
     });

--- a/backend/src/validators/workOrderValidators.ts
+++ b/backend/src/validators/workOrderValidators.ts
@@ -1,0 +1,83 @@
+import { z } from 'zod';
+import { normalizeToObjectIdString } from '../lib/ids';
+
+const OBJECT_ID_ERROR = 'Value must be a valid ObjectId string';
+const ISO_8601_REGEX = /^(\d{4}-\d{2}-\d{2})(T\d{2}:\d{2}(:\d{2}(\.\d{1,3})?)?(Z|([+-]\d{2}:\d{2})))?$/;
+
+function validateObjectId(value: string, ctx: z.RefinementCtx) {
+  try {
+    normalizeToObjectIdString(value);
+  } catch (error) {
+    if (error instanceof TypeError) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: OBJECT_ID_ERROR,
+      });
+      return;
+    }
+
+    throw error;
+  }
+}
+
+export const objectIdSchema = z
+  .string({ required_error: OBJECT_ID_ERROR, invalid_type_error: OBJECT_ID_ERROR })
+  .trim()
+  .min(1, { message: OBJECT_ID_ERROR })
+  .superRefine(validateObjectId)
+  .transform((value) => normalizeToObjectIdString(value));
+
+const isoDateSchema = z
+  .string({ invalid_type_error: 'dueDate must be an ISO 8601 date string' })
+  .trim()
+  .refine((value) => ISO_8601_REGEX.test(value), {
+    message: 'dueDate must be an ISO 8601 date string',
+  })
+  .refine((value) => {
+    const parsed = new Date(value);
+    return !Number.isNaN(parsed.getTime());
+  }, {
+    message: 'dueDate must be an ISO 8601 date string',
+  });
+
+export const statusEnum = z.enum(['requested', 'assigned', 'in_progress', 'completed', 'cancelled']);
+export const priorityEnum = z.enum(['low', 'medium', 'high', 'urgent']);
+
+export const createWorkOrderValidator = z
+  .object({
+    title: z
+      .string({ required_error: 'Title is required', invalid_type_error: 'Title is required' })
+      .trim()
+      .min(3, 'Title must be at least 3 characters long')
+      .max(120, 'Title must be 120 characters or fewer'),
+    description: z
+      .string({ invalid_type_error: 'Description must be a string' })
+      .trim()
+      .max(4000, 'Description must be 4000 characters or fewer')
+      .optional()
+      .transform((value) => (value && value.length > 0 ? value : undefined)),
+    status: statusEnum.optional(),
+    priority: priorityEnum.optional(),
+    assetId: objectIdSchema.optional(),
+    assignedTo: z.union([objectIdSchema, z.null()]).optional(),
+    category: z
+      .string({ invalid_type_error: 'Category must be a string' })
+      .trim()
+      .max(120, 'Category must be 120 characters or fewer')
+      .optional()
+      .transform((value) => (value && value.length > 0 ? value : undefined)),
+    dueDate: isoDateSchema.optional(),
+    attachments: z
+      .array(objectIdSchema, {
+        invalid_type_error: 'attachments must be an array of ObjectId strings',
+      })
+      .optional()
+      .transform((value) => (value ? Array.from(new Set(value)) : [])),
+  })
+  .strict()
+  .transform((value) => ({
+    ...value,
+    attachments: value.attachments ?? [],
+  }));
+
+export type CreateWorkOrderInput = z.infer<typeof createWorkOrderValidator>;


### PR DESCRIPTION
## Summary
- add a shared create work order validator that enforces ids, dates, and attachment input
- update the Prisma model, seeding helpers, and work order routes to use assignedTo, category, dueDate, and attachments
- refresh the simple work order API and tests to drop checklist-era fields while returning the new metadata

## Testing
- npm test --prefix backend

------
https://chatgpt.com/codex/tasks/task_e_68dd2d5002a48323bbca327127bb82b9