### PR TITLE
Connect assets API and refactor work order form

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import { Layout } from './components/Layout';
+import { Toaster } from './components/ui/toaster';
 import { AuthProvider, useAuth } from './hooks/useAuth';
 import { Dashboard } from './pages/Dashboard';
 import { WorkOrders } from './pages/WorkOrders';
@@ -37,6 +38,7 @@ function App() {
     <QueryClientProvider client={queryClient}>
       <AuthProvider>
         <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+          <Toaster />
           <Routes>
             <Route path="/login" element={<Login />} />
             <Route

--- a/frontend/src/components/ui/toaster.jsx
+++ b/frontend/src/components/ui/toaster.jsx
@@ -1,0 +1,73 @@
+import { useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { X } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { useToastStore } from '@/hooks/useToast';
+
+const variantStyles = {
+  default: 'border-gray-200 bg-white text-gray-900',
+  success: 'border-green-200 bg-green-50 text-green-900',
+  error: 'border-red-200 bg-red-50 text-red-900',
+  info: 'border-blue-200 bg-blue-50 text-blue-900',
+};
+
+export function Toaster() {
+  const [mounted, setMounted] = useState(false);
+  const toasts = useToastStore((state) => state.toasts);
+  const dismiss = useToastStore((state) => state.dismiss);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const container = useMemo(() => {
+    if (typeof document === 'undefined') return null;
+    let element = document.getElementById('toast-root');
+    if (!element) {
+      element = document.createElement('div');
+      element.setAttribute('id', 'toast-root');
+      document.body.appendChild(element);
+    }
+    return element;
+  }, []);
+
+  if (!mounted || !container) {
+    return null;
+  }
+
+  return createPortal(
+    <div className="pointer-events-none fixed bottom-4 right-4 z-50 flex w-full max-w-sm flex-col gap-3">
+      {toasts.map((toast) => {
+        const style = variantStyles[toast.variant] || variantStyles.default;
+        return (
+          <div
+            key={toast.id}
+            className={`pointer-events-auto rounded-lg border p-4 shadow-lg transition-all ${style}`}
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="space-y-1">
+                {toast.title && (
+                  <p className="text-sm font-semibold">{toast.title}</p>
+                )}
+                {toast.description && (
+                  <p className="text-sm text-gray-600">{toast.description}</p>
+                )}
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 text-gray-500 hover:text-gray-700"
+                onClick={() => dismiss(toast.id)}
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+        );
+      })}
+    </div>,
+    container,
+  );
+}

--- a/frontend/src/components/work-orders/WorkOrderForm.jsx
+++ b/frontend/src/components/work-orders/WorkOrderForm.jsx
@@ -1,61 +1,91 @@
-import { useMemo, useState } from 'react';
-import { useFieldArray, useForm } from 'react-hook-form';
+import { useEffect, useMemo, useState } from 'react';
+import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { api } from '@/lib/api';
+import { useToast } from '@/hooks/useToast';
+import { formatDate } from '@/lib/utils';
+
+const fileSchema = z.custom(
+  (file) =>
+    typeof file === 'undefined' ||
+    (typeof File !== 'undefined' && file instanceof File),
+  {
+    message: 'Select a valid file',
+  },
+);
 
 const workOrderSchema = z.object({
   title: z.string().min(1, 'Title is required'),
-  description: z.string().min(1, 'Description is required'),
+  description: z
+    .string()
+    .max(2000, 'Description must be 2000 characters or fewer')
+    .optional()
+    .or(z.literal('')),
+  assetId: z.string().min(1, 'Asset is required'),
   priority: z.enum(['low', 'medium', 'high', 'urgent'], {
     errorMap: () => ({ message: 'Select a priority' }),
   }),
-  assetId: z.string().min(1, 'Asset is required'),
-  lineName: z.string().min(1, 'Line name is required'),
-  stationNumber: z.string().min(1, 'Station number is required'),
-  assignees: z
-    .array(z.string().min(1, 'Assignee is required'))
-    .min(1, 'Add at least one assignee'),
-  checklists: z
-    .array(
-      z.object({
-        text: z.string().min(1, 'Checklist item is required'),
-        note: z.string().optional(),
-      })
-    )
-    .min(1, 'Add at least one checklist item'),
+  dueDate: z
+    .string()
+    .optional()
+    .refine(
+      (value) => !value || !Number.isNaN(Date.parse(value)),
+      'Enter a valid due date',
+    ),
+  assignedTo: z
+    .string()
+    .max(255, 'Assigned to must be 255 characters or fewer')
+    .optional()
+    .or(z.literal('')),
+  category: z
+    .string()
+    .max(255, 'Category must be 255 characters or fewer')
+    .optional()
+    .or(z.literal('')),
+  attachments: z.array(fileSchema).default([]),
 });
 
-export function WorkOrderForm({ onClose, onSuccess }) {
+export function WorkOrderForm({ asset, onClose, onSuccess }) {
   const [submitError, setSubmitError] = useState('');
+  const { toast } = useToast();
+
+  const assetIdentifier = useMemo(
+    () => asset?._id ?? asset?.id ?? asset?.assetId ?? asset?.tag ?? '',
+    [asset],
+  );
+
   const form = useForm({
     resolver: zodResolver(workOrderSchema),
     defaultValues: {
       title: '',
       description: '',
+      assetId: assetIdentifier,
       priority: 'medium',
-      assetId: '',
-      lineName: '',
-      stationNumber: '',
-      assignees: [''],
-      checklists: [{ text: '', note: '' }],
+      dueDate: '',
+      assignedTo: '',
+      category: '',
+      attachments: [],
     },
   });
 
-  const {
-    control,
-    handleSubmit,
-    register,
-    setError,
-    formState: { errors, isSubmitting },
-    reset,
-  } = form;
+  const { register, handleSubmit, setError, setValue, watch, formState } = form;
+  const { errors, isSubmitting } = formState;
 
-  const assigneeFields = useFieldArray({ control, name: 'assignees' });
-  const checklistFields = useFieldArray({ control, name: 'checklists' });
+  const attachments = watch('attachments') || [];
+
+  useEffect(() => {
+    register('attachments');
+  }, [register]);
+
+  useEffect(() => {
+    if (assetIdentifier) {
+      setValue('assetId', assetIdentifier, { shouldValidate: true });
+    }
+  }, [assetIdentifier, setValue]);
 
   const priorityOptions = useMemo(
     () => [
@@ -64,11 +94,30 @@ export function WorkOrderForm({ onClose, onSuccess }) {
       { value: 'high', label: 'High' },
       { value: 'urgent', label: 'Urgent' },
     ],
-    []
+    [],
   );
 
   const handleApiErrors = (error) => {
-    if (!error) return;
+    if (!error) {
+      const fallback = 'Unable to create work order';
+      setSubmitError(fallback);
+      return fallback;
+    }
+
+    let message = error.message || 'Unable to create work order';
+
+    if (error.fields && typeof error.fields === 'object') {
+      Object.entries(error.fields).forEach(([field, fieldMessage]) => {
+        const resolvedMessage = fieldMessage || message;
+        setError(field, {
+          type: 'server',
+          message: resolvedMessage,
+        });
+        if (resolvedMessage) {
+          message = resolvedMessage;
+        }
+      });
+    }
 
     if (Array.isArray(error.details)) {
       error.details.forEach((detail) => {
@@ -82,11 +131,13 @@ export function WorkOrderForm({ onClose, onSuccess }) {
             type: 'server',
             message: detail.message || error.message || 'Validation error',
           });
+          message = detail.message || message;
         }
       });
     }
 
-    setSubmitError(error.message || 'Unable to create work order');
+    setSubmitError(message);
+    return message;
   };
 
   const onSubmit = handleSubmit(async (values) => {
@@ -94,36 +145,104 @@ export function WorkOrderForm({ onClose, onSuccess }) {
 
     const payload = {
       title: values.title,
-      description: values.description,
+      description: values.description?.trim() ? values.description : undefined,
       priority: values.priority,
       assetId: values.assetId,
-      lineName: values.lineName,
-      stationNumber: values.stationNumber,
-      assignees: values.assignees.filter((id) => id.trim().length > 0),
-      checklists: values.checklists
-        .filter((item) => item.text.trim().length > 0)
-        .map((item) => ({
-          text: item.text,
-          note: item.note || undefined,
-        })),
+      dueDate: values.dueDate ? new Date(values.dueDate).toISOString() : undefined,
+      assignedTo: values.assignedTo?.trim() ? values.assignedTo : undefined,
+      category: values.category?.trim() ? values.category : undefined,
+      attachments: attachments.map((file) => ({
+        name: file.name,
+        size: file.size,
+        type: file.type,
+        lastModified: file.lastModified,
+      })),
     };
 
     try {
-      const result = await api.post('/api/work-orders', payload);
-      reset();
+      const result = await api.post('/work-orders', payload);
+      form.reset({
+        title: '',
+        description: '',
+        assetId: assetIdentifier || '',
+        priority: 'medium',
+        dueDate: '',
+        assignedTo: '',
+        category: '',
+        attachments: [],
+      });
+      toast({
+        title: 'Work order created',
+        description: 'The work order was created successfully.',
+        variant: 'success',
+      });
       if (typeof onSuccess === 'function') {
         onSuccess(result?.data ?? result);
+      }
+      if (!onSuccess && typeof onClose === 'function') {
+        onClose();
       }
     } catch (error) {
       const payloadError = error?.data?.error ?? {
         message: error?.message || 'Unable to create work order',
       };
-      handleApiErrors(payloadError);
+      const message = handleApiErrors(payloadError);
+      toast({
+        title: 'Failed to create work order',
+        description: message,
+        variant: 'error',
+      });
     }
   });
 
+  const handleAttachmentChange = (event) => {
+    const files = Array.from(event.target.files ?? []);
+    setValue('attachments', [...attachments, ...files], {
+      shouldValidate: true,
+    });
+    event.target.value = '';
+  };
+
+  const handleRemoveAttachment = (index) => {
+    const next = attachments.filter((_, i) => i !== index);
+    setValue('attachments', next, { shouldValidate: true });
+  };
+
+  const assetMetadata = useMemo(() => {
+    if (!asset) return [];
+
+    const installedValue = asset.purchasedDate || asset.installedAt;
+    const formattedInstalled = installedValue ? formatDate(installedValue) : null;
+
+    return [
+      { label: 'Tag', value: asset.tag || asset.assetTag || asset.assetId },
+      { label: 'Location', value: asset.location },
+      { label: 'Status', value: asset.status },
+      formattedInstalled
+        ? {
+            label: 'Installed',
+            value: formattedInstalled,
+          }
+        : null,
+    ].filter((item) => item && item.value);
+  }, [asset]);
+
   return (
     <form className="space-y-6" onSubmit={onSubmit}>
+      {asset && (
+        <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-3">
+          <p className="text-sm font-semibold text-gray-900">{asset.name}</p>
+          <div className="mt-2 grid grid-cols-1 gap-2 text-sm text-gray-600 sm:grid-cols-2">
+            {assetMetadata.map((item) => (
+              <div key={item.label} className="flex items-center gap-2">
+                <span className="font-medium text-gray-700">{item.label}:</span>
+                <span className="truncate">{item.value}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
       <div className="space-y-2">
         <label className="block text-sm font-medium text-gray-700">Title</label>
         <Input placeholder="Work order title" {...register('title')} />
@@ -133,7 +252,9 @@ export function WorkOrderForm({ onClose, onSuccess }) {
       </div>
 
       <div className="space-y-2">
-        <label className="block text-sm font-medium text-gray-700">Description</label>
+        <label className="block text-sm font-medium text-gray-700">
+          Description <span className="text-gray-400">(optional)</span>
+        </label>
         <textarea
           {...register('description')}
           className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
@@ -145,7 +266,7 @@ export function WorkOrderForm({ onClose, onSuccess }) {
         )}
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
         <div className="space-y-2">
           <label className="block text-sm font-medium text-gray-700">Priority</label>
           <select
@@ -166,140 +287,85 @@ export function WorkOrderForm({ onClose, onSuccess }) {
 
         <div className="space-y-2">
           <label className="block text-sm font-medium text-gray-700">Asset ID</label>
-          <Input placeholder="Asset identifier" {...register('assetId')} />
+          <Input
+            placeholder="Asset identifier"
+            {...register('assetId')}
+            readOnly={Boolean(assetIdentifier)}
+            disabled={Boolean(assetIdentifier)}
+          />
           {errors.assetId && (
             <p className="text-sm text-red-600">{errors.assetId.message}</p>
           )}
         </div>
 
         <div className="space-y-2">
-          <label className="block text-sm font-medium text-gray-700">Line Name</label>
-          <Input placeholder="Associated line" {...register('lineName')} />
-          {errors.lineName && (
-            <p className="text-sm text-red-600">{errors.lineName.message}</p>
+          <label className="block text-sm font-medium text-gray-700">
+            Due Date <span className="text-gray-400">(optional)</span>
+          </label>
+          <Input type="date" {...register('dueDate')} />
+          {errors.dueDate && (
+            <p className="text-sm text-red-600">{errors.dueDate.message}</p>
           )}
         </div>
 
         <div className="space-y-2">
-          <label className="block text-sm font-medium text-gray-700">Station Number</label>
-          <Input placeholder="Station identifier" {...register('stationNumber')} />
-          {errors.stationNumber && (
-            <p className="text-sm text-red-600">{errors.stationNumber.message}</p>
+          <label className="block text-sm font-medium text-gray-700">
+            Assigned To <span className="text-gray-400">(optional)</span>
+          </label>
+          <Input placeholder="Technician or team" {...register('assignedTo')} />
+          {errors.assignedTo && (
+            <p className="text-sm text-red-600">{errors.assignedTo.message}</p>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-gray-700">
+            Category <span className="text-gray-400">(optional)</span>
+          </label>
+          <Input placeholder="Maintenance category" {...register('category')} />
+          {errors.category && (
+            <p className="text-sm text-red-600">{errors.category.message}</p>
           )}
         </div>
       </div>
 
-      <div className="space-y-3">
-        <div className="flex items-center justify-between">
-          <div>
-            <h3 className="text-sm font-medium text-gray-900">Assignees</h3>
-            <p className="text-sm text-gray-500">
-              Assign at least one technician or team member responsible for this work.
-            </p>
-          </div>
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => assigneeFields.append('')}
-          >
-            Add Assignee
-          </Button>
-        </div>
-        {errors.assignees && !Array.isArray(errors.assignees) && (
-          <p className="text-sm text-red-600">{errors.assignees.message}</p>
+      <div className="space-y-2">
+        <label className="block text-sm font-medium text-gray-700">
+          Attachments <span className="text-gray-400">(optional)</span>
+        </label>
+        <input
+          type="file"
+          multiple
+          onChange={handleAttachmentChange}
+          className="w-full rounded-md border border-input bg-white px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        />
+        {errors.attachments && !Array.isArray(errors.attachments) && (
+          <p className="text-sm text-red-600">{errors.attachments.message}</p>
         )}
-        <div className="space-y-3">
-          {assigneeFields.fields.map((field, index) => (
-            <div key={field.id} className="flex items-center space-x-2">
-              <Input
-                placeholder="Assignee ID or email"
-                {...register(`assignees.${index}`)}
-              />
-              <Button
-                type="button"
-                variant="ghost"
-                onClick={() => assigneeFields.remove(index)}
-                disabled={assigneeFields.fields.length === 1}
+        {attachments.length > 0 && (
+          <ul className="space-y-2 rounded-md border border-dashed border-gray-300 bg-gray-50 p-3 text-sm text-gray-700">
+            {attachments.map((file, index) => (
+              <li
+                key={`${file.name}-${file.lastModified ?? index}`}
+                className="flex items-center justify-between gap-2"
               >
-                Remove
-              </Button>
-            </div>
-          ))}
-        </div>
-        {Array.isArray(errors.assignees) &&
-          errors.assignees.map((assigneeError, index) =>
-            assigneeError ? (
-              <p key={`assignee-error-${index}`} className="text-sm text-red-600">
-                {assigneeError.message}
-              </p>
-            ) : null
-          )}
-      </div>
-
-      <div className="space-y-3">
-        <div className="flex items-center justify-between">
-          <div>
-            <h3 className="text-sm font-medium text-gray-900">Checklist</h3>
-            <p className="text-sm text-gray-500">
-              Outline the tasks that must be completed for this work order.
-            </p>
-          </div>
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => checklistFields.append({ text: '', note: '' })}
-          >
-            Add Item
-          </Button>
-        </div>
-        {errors.checklists && !Array.isArray(errors.checklists) && (
-          <p className="text-sm text-red-600">{errors.checklists.message}</p>
-        )}
-        <div className="space-y-4">
-          {checklistFields.fields.map((field, index) => (
-            <div key={field.id} className="space-y-2 rounded-lg border border-border p-4">
-              <div className="flex items-start justify-between">
-                <div className="flex-1 space-y-2">
-                  <label className="block text-sm font-medium text-gray-700">
-                    Item
-                  </label>
-                  <Input
-                    placeholder="Checklist task"
-                    {...register(`checklists.${index}.text`)}
-                  />
-                  {errors.checklists?.[index]?.text && (
-                    <p className="text-sm text-red-600">
-                      {errors.checklists[index].text.message}
-                    </p>
-                  )}
-                  <label className="block text-sm font-medium text-gray-700">
-                    Note (optional)
-                  </label>
-                  <textarea
-                    {...register(`checklists.${index}.note`)}
-                    className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                    rows={2}
-                    placeholder="Add guidance or notes for this task"
-                  />
-                  {errors.checklists?.[index]?.note && (
-                    <p className="text-sm text-red-600">
-                      {errors.checklists[index].note.message}
-                    </p>
-                  )}
+                <div className="min-w-0 flex-1">
+                  <p className="truncate font-medium text-gray-900">{file.name}</p>
+                  <p className="text-xs text-gray-500">
+                    {(file.size / 1024).toFixed(1)} KB · {file.type || 'Unknown type'}
+                  </p>
                 </div>
                 <Button
                   type="button"
                   variant="ghost"
-                  className="ml-4"
-                  onClick={() => checklistFields.remove(index)}
-                  disabled={checklistFields.fields.length === 1}
+                  onClick={() => handleRemoveAttachment(index)}
                 >
                   Remove
                 </Button>
-              </div>
-            </div>
-          ))}
-        </div>
+              </li>
+            ))}
+          </ul>
+        )}
       </div>
 
       {submitError && <p className="text-sm text-red-600">{submitError}</p>}

--- a/frontend/src/hooks/useToast.js
+++ b/frontend/src/hooks/useToast.js
@@ -1,0 +1,67 @@
+import { create } from 'zustand';
+
+const generateId = () => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2);
+};
+
+const DEFAULT_DURATION = 4000;
+
+export const useToastStore = create((set, get) => ({
+  toasts: [],
+  addToast: (toast) => {
+    const id = toast.id ?? generateId();
+    const duration =
+      typeof toast.duration === 'number' && toast.duration > 0
+        ? toast.duration
+        : DEFAULT_DURATION;
+
+    set((state) => ({
+      toasts: [
+        ...state.toasts,
+        {
+          id,
+          title: toast.title,
+          description: toast.description,
+          variant: toast.variant || 'default',
+          duration,
+        },
+      ],
+    }));
+
+    if (duration !== Infinity) {
+      const timeoutId = setTimeout(() => {
+        const toastExists = get().toasts.some((item) => item.id === id);
+        if (toastExists) {
+          set((state) => ({
+            toasts: state.toasts.filter((item) => item.id !== id),
+          }));
+        }
+      }, duration);
+
+      return { id, timeoutId };
+    }
+
+    return { id };
+  },
+  dismiss: (id) => {
+    set((state) => ({
+      toasts: state.toasts.filter((toast) => toast.id !== id),
+    }));
+  },
+}));
+
+export function useToast() {
+  const addToast = useToastStore((state) => state.addToast);
+  const dismiss = useToastStore((state) => state.dismiss);
+
+  return {
+    toast: (toast) => {
+      const result = addToast(toast);
+      return result.id;
+    },
+    dismiss,
+  };
+}


### PR DESCRIPTION
## Summary
- load assets from `/api/assets` and open an asset-scoped work order modal
- refactor the work order form to the new contract, including validation, attachments, and API submission
- add a lightweight toast system and register the global toaster for success/error feedback

## Testing
- npm run lint *(fails: Invalid option '--ext' because eslint.config.js disallows that flag)*

------
https://chatgpt.com/codex/tasks/task_e_68dd2d5056a483238a60b053c7e9c981