### PR TITLE
Align frontend API helper with backend auth updates

### DIFF
--- a/frontend/src/components/work-orders/WorkOrderForm.jsx
+++ b/frontend/src/components/work-orders/WorkOrderForm.jsx
@@ -70,7 +70,19 @@ export function WorkOrderForm({ onClose, onSuccess }) {
   const handleApiErrors = (error) => {
     if (!error) return;
 
-    if (Array.isArray(error.details)) {
+    if (error.fields && typeof error.fields === 'object') {
+      Object.entries(error.fields).forEach(([fieldPath, fieldError]) => {
+        if (!fieldPath) return;
+
+        const messages = Array.isArray(fieldError) ? fieldError : [fieldError];
+        const message = messages.find((msg) => typeof msg === 'string' && msg.trim().length > 0);
+
+        setError(fieldPath, {
+          type: 'server',
+          message: message || error.message || 'Validation error',
+        });
+      });
+    } else if (Array.isArray(error.details)) {
       error.details.forEach((detail) => {
         if (!detail?.path) return;
         const fieldPath = Array.isArray(detail.path)
@@ -109,7 +121,7 @@ export function WorkOrderForm({ onClose, onSuccess }) {
     };
 
     try {
-      const result = await api.post('/api/work-orders', payload);
+      const result = await api.post('/work-orders', payload);
       reset();
       if (typeof onSuccess === 'function') {
         onSuccess(result?.data ?? result);

--- a/frontend/src/hooks/useAuth.jsx
+++ b/frontend/src/hooks/useAuth.jsx
@@ -35,7 +35,7 @@ export function AuthProvider({ children }) {
     setError('');
 
     try {
-      const res = await api.post('/api/auth/login', { email, password });
+      const res = await api.post('/auth/login', { email, password });
       const { token: nextToken, user: nextUser } = res?.data ?? {};
 
       if (!nextToken) {

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,10 +1,32 @@
-const BASE = import.meta?.env?.VITE_API_URL || 'http://localhost:5010';
+const BASE = import.meta?.env?.VITE_API_URL || 'http://localhost:5010/api';
+
+function readToken() {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    return window.localStorage.getItem('token');
+  } catch {
+    return null;
+  }
+}
 
 async function request(path, options = {}) {
+  const token = readToken();
+  const headers = {
+    'Content-Type': 'application/json',
+    ...(options.headers || {}),
+  };
+
+  if (token && !headers.Authorization) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
   const res = await fetch(`${BASE}${path}`, {
     method: 'GET',
-    headers: { 'Content-Type': 'application/json', ...(options.headers || {}) },
     ...options,
+    headers,
   });
 
   const contentType = res.headers.get('content-type') || '';
@@ -12,10 +34,21 @@ async function request(path, options = {}) {
   const data = isJson ? await res.json().catch(() => ({})) : null;
 
   if (!res.ok) {
-    const message = data?.error?.message || `HTTP ${res.status}`;
-    const error = new Error(message);
+    const errorPayload = data?.error ?? {};
+    const rawData = data && typeof data === 'object' ? data : {};
+    const normalizedError = {
+      code: errorPayload.code ?? `HTTP_${res.status}`,
+      message:
+        errorPayload.message || data?.message || data?.error?.message || `HTTP ${res.status}`,
+      fields: errorPayload.fields ?? data?.fields ?? null,
+    };
+
+    const error = new Error(normalizedError.message);
     error.status = res.status;
-    error.data = data;
+    error.code = normalizedError.code;
+    error.fields = normalizedError.fields;
+    error.data = { ...rawData, error: normalizedError };
+
     throw error;
   }
 

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -20,7 +20,7 @@ export function Dashboard() {
   const { data: summary } = useQuery({
     queryKey: ['dashboard', 'summary'],
     queryFn: async () => {
-      const result = await api.get('/api/dashboard/summary');
+      const result = await api.get('/dashboard/summary');
       return result?.data ?? result;
     },
   });
@@ -28,7 +28,7 @@ export function Dashboard() {
   const { data: trends } = useQuery({
     queryKey: ['dashboard', 'trends'],
     queryFn: async () => {
-      const result = await api.get('/api/dashboard/trends');
+      const result = await api.get('/dashboard/trends');
       return result?.data ?? result;
     },
   });
@@ -36,7 +36,7 @@ export function Dashboard() {
   const { data: activity } = useQuery({
     queryKey: ['dashboard', 'activity'],
     queryFn: async () => {
-      const result = await api.get('/api/dashboard/activity');
+      const result = await api.get('/dashboard/activity');
       return result?.data ?? result;
     },
   });


### PR DESCRIPTION
## Summary
- default the API base URL to include `/api` and attach stored bearer tokens to each request
- normalize error payloads so backend `{ error: { code, message, fields } }` responses propagate to consumers
- update dashboard, auth, and work order form calls to use the new base URL and surface field validation messages

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd2d559a04832384608cf9e2a59ebc