### PR TITLE
Align work order assignee field with Prisma schema

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -32,7 +32,7 @@ model User {
 
   tenant            Tenant      @relation(fields: [tenantId], references: [id])
   createdWorkOrders WorkOrder[] @relation("CreatedBy")
-  assignedWorkOrders WorkOrder[] @relation("AssignedTo")
+  assignedWorkOrders WorkOrder[] @relation("Assignee")
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -86,7 +86,7 @@ model WorkOrder {
   priority      WorkOrderPriority @default(medium)
   status        WorkOrderStatus   @default(requested)
   assetId       String?           @map("asset_id") @db.ObjectId
-  assignedTo    String?           @map("assigned_to") @db.ObjectId
+  assigneeId    String?           @map("assigned_to") @db.ObjectId
   category      String?
   dueDate       DateTime?         @map("due_date")
   attachments   String[]          @default([])
@@ -96,10 +96,10 @@ model WorkOrder {
   timeSpentMin  Int?              @map("time_spent_min")
   failureCode   String?           @map("failure_code")
   pmTaskId      String?           @map("pm_task_id") @db.ObjectId
-  requestedBy   String            @map("created_by") @db.ObjectId
+  createdBy     String            @map("created_by") @db.ObjectId
 
   tenant        Tenant   @relation(fields: [tenantId], references: [id])
-  assignedToUser User?    @relation("AssignedTo", fields: [assignedTo], references: [id])
+  assignee      User?    @relation("Assignee", fields: [assigneeId], references: [id])
   createdByUser User     @relation("CreatedBy", fields: [createdBy], references: [id])
 
   asset         Asset?   @relation(fields: [assetId], references: [id])

--- a/backend/src/controllers/workOrderController.ts
+++ b/backend/src/controllers/workOrderController.ts
@@ -40,8 +40,8 @@ function serializeWorkOrder(workOrder: {
   priority: string;
   status: string;
   assetId: string | null;
-  requestedBy: string;
-  assignedTo: string | null;
+  createdBy: string;
+  assigneeId: string | null;
   dueDate: Date | null;
   category: string | null;
   attachments: Prisma.JsonValue | null;
@@ -61,8 +61,8 @@ function serializeWorkOrder(workOrder: {
     priority: workOrder.priority,
     status: workOrder.status,
     assetId: workOrder.assetId,
-    requestedBy: workOrder.requestedBy,
-    assignedTo: workOrder.assignedTo,
+    requestedBy: workOrder.createdBy,
+    assigneeId: workOrder.assigneeId,
     dueDate: workOrder.dueDate ? workOrder.dueDate.toISOString() : null,
     category: workOrder.category,
     attachments,
@@ -110,8 +110,8 @@ export async function createWorkOrder(req: TenantScopedRequest, res: Response) {
         priority: data.priority ?? 'medium',
         status: 'requested',
         assetId: data.assetId ?? null,
-        requestedBy: req.userId,
-        assignedTo: data.assignedTo ?? null,
+        createdBy: req.userId,
+        assigneeId: data.assigneeId ?? null,
         dueDate: data.dueDate ? new Date(data.dueDate) : null,
         category: data.category ?? null,
         attachments: (data.attachments ?? []) as Prisma.JsonValue,

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -213,7 +213,7 @@ async function seedDefaultsNoTxn(): Promise<void> {
         description: workOrderDescription,
         priority: 'medium',
         status: 'requested',
-        assignedTo: adminId,
+        assigneeId: adminId,
         createdBy: adminId,
 
       },

--- a/backend/src/routes/simpleWorkOrders.test.ts
+++ b/backend/src/routes/simpleWorkOrders.test.ts
@@ -84,8 +84,8 @@ describe('workOrderController.createWorkOrder', () => {
       status: 'requested',
       assetId: 'aaaaaaaaaaaaaaaaaaaaaaaa',
       asset: null,
-      assignedTo: null,
-      assignedToUser: null,
+      assigneeId: null,
+      assignee: null,
       category: null,
       attachments: [],
       dueDate: null,
@@ -102,7 +102,7 @@ describe('workOrderController.createWorkOrder', () => {
         description: 'Inspect the conveyor for issues',
         priority: 'high',
         assetId: 'AAAAAAAAAAAAAAAAAAAAAAAA',
-        assignedTo: 'BBBBBBBBBBBBBBBBBBBBBBBB',
+        assigneeId: 'BBBBBBBBBBBBBBBBBBBBBBBB',
         dueDate: now.toISOString(),
         category: 'maintenance',
         attachments: [
@@ -126,7 +126,7 @@ describe('workOrderController.createWorkOrder', () => {
         data: expect.objectContaining({
           assetId: 'aaaaaaaaaaaaaaaaaaaaaaaa',
           attachments: [],
-          assignedTo: null,
+          assigneeId: null,
           category: undefined,
           dueDate: undefined,
           priority: 'medium',
@@ -148,7 +148,7 @@ describe('workOrderController.createWorkOrder', () => {
         status: 'requested',
         assetId: 'aaaaaaaaaaaaaaaaaaaaaaaa',
         attachments: [],
-        assignedTo: null,
+        assigneeId: null,
         category: null,
         dueDate: null,
 
@@ -168,7 +168,7 @@ describe('workOrderController.createWorkOrder', () => {
         status: 'requested',
         assetId: 'aaaaaaaaaaaaaaaaaaaaaaaa',
         requestedBy: 'user-1',
-        assignedTo: 'bbbbbbbbbbbbbbbbbbbbbbbb',
+        assigneeId: 'bbbbbbbbbbbbbbbbbbbbbbbb',
         dueDate: now.toISOString(),
         category: 'maintenance',
         attachments: [

--- a/backend/src/routes/simpleWorkOrders.ts
+++ b/backend/src/routes/simpleWorkOrders.ts
@@ -12,7 +12,7 @@ type WorkOrderWithRelations = Prisma.WorkOrderGetPayload<{
   include: {
     asset: { select: { id: true; code: true; name: true } };
     createdByUser: { select: { id: true; name: true } };
-    assignedToUser: { select: { id: true; name: true } };
+    assignee: { select: { id: true; name: true } };
   };
 }>;
 
@@ -26,8 +26,8 @@ function mapWorkOrder(workOrder: WorkOrderWithRelations) {
     assetId: workOrder.assetId ?? null,
     assetName: workOrder.asset?.name ?? null,
     assetCode: workOrder.asset?.code ?? null,
-    assignedTo: workOrder.assignedTo ?? null,
-    assignedToName: workOrder.assignedToUser?.name ?? null,
+    assigneeId: workOrder.assigneeId ?? null,
+    assigneeName: workOrder.assignee?.name ?? null,
     category: workOrder.category ?? null,
     attachments: Array.isArray(workOrder.attachments) ? workOrder.attachments : [],
     requestedById: workOrder.createdByUser?.id ?? null,
@@ -82,7 +82,7 @@ router.get(
     }
 
     if (typeof assignee === 'string' && assignee) {
-      where.assignedTo = assignee;
+      where.assigneeId = assignee;
     }
 
     if (typeof category === 'string' && category.trim().length > 0) {
@@ -125,7 +125,7 @@ router.get(
       include: {
         asset: { select: { id: true, code: true, name: true } },
         createdByUser: { select: { id: true, name: true } },
-        assignedToUser: { select: { id: true, name: true } },
+        assignee: { select: { id: true, name: true } },
       },
       orderBy: { createdAt: 'desc' },
     });
@@ -165,7 +165,7 @@ router.post(
         tenantId: defaultUser.tenantId,
         createdBy: defaultUser.id,
         assetId: payload.assetId ?? undefined,
-        assignedTo: payload.assignedTo ?? null,
+        assigneeId: payload.assigneeId ?? null,
         category: payload.category ?? undefined,
         dueDate: payload.dueDate ? new Date(payload.dueDate) : undefined,
         attachments: payload.attachments ?? [],
@@ -173,7 +173,7 @@ router.post(
       include: {
         asset: { select: { id: true, code: true, name: true } },
         createdByUser: { select: { id: true, name: true } },
-        assignedToUser: { select: { id: true, name: true } },
+        assignee: { select: { id: true, name: true } },
       },
     });
 

--- a/backend/src/routes/workOrders.ts
+++ b/backend/src/routes/workOrders.ts
@@ -22,7 +22,7 @@ const updateWorkOrderSchema = z.object({
   status: statusEnum.optional(),
   priority: priorityEnum.optional(),
   assetId: objectIdSchema.optional().nullable(),
-  assignedTo: z.union([objectIdSchema, z.null()]).optional(),
+  assigneeId: z.union([objectIdSchema, z.null()]).optional(),
   category: z.string().trim().max(120).optional().nullable(),
   dueDate: z
     .union([
@@ -49,7 +49,7 @@ const updateWorkOrderSchema = z.object({
 
 
 const workOrderInclude = {
-  assignedToUser: {
+  assignee: {
     select: {
       id: true,
       name: true,
@@ -69,12 +69,12 @@ function serializeWorkOrder(workOrder: WorkOrderWithRelations) {
     priority: workOrder.priority,
     status: workOrder.status,
     assetId: workOrder.assetId ?? null,
-    assignedTo: workOrder.assignedTo ?? null,
-    assignedToUser: workOrder.assignedToUser
+    assigneeId: workOrder.assigneeId ?? null,
+    assignee: workOrder.assignee
       ? {
-          id: workOrder.assignedToUser.id,
-          name: workOrder.assignedToUser.name,
-          email: workOrder.assignedToUser.email,
+          id: workOrder.assignee.id,
+          name: workOrder.assignee.name,
+          email: workOrder.assignee.email,
         }
       : null,
     category: workOrder.category ?? null,
@@ -128,7 +128,7 @@ router.post('/', asyncHandler(async (req: AuthRequest, res) => {
       status: (data.status ?? 'requested') as WorkOrderStatus,
       priority: data.priority ?? 'medium',
       assetId: data.assetId ?? undefined,
-      assignedTo: data.assignedTo ?? null,
+      assigneeId: data.assigneeId ?? null,
       category: data.category ?? undefined,
       dueDate: data.dueDate ? new Date(data.dueDate) : undefined,
       attachments: data.attachments ?? [],
@@ -176,8 +176,8 @@ router.put('/:id', asyncHandler(async (req: AuthRequest, res) => {
     updateData.assetId = data.assetId ?? null;
   }
 
-  if ('assignedTo' in data) {
-    updateData.assignedTo = data.assignedTo ?? null;
+  if ('assigneeId' in data) {
+    updateData.assigneeId = data.assigneeId ?? null;
   }
 
   if ('category' in data) {

--- a/backend/src/scripts/seed.ts
+++ b/backend/src/scripts/seed.ts
@@ -49,7 +49,7 @@ async function main(): Promise<void> {
         description: 'Inspect the demo asset and confirm it is running.',
         priority: 'medium',
         status: 'requested',
-        assignedTo: adminUser.id,
+        assigneeId: adminUser.id,
         createdBy: adminUser.id,
 
       },

--- a/backend/src/validators/createWorkOrderValidator.ts
+++ b/backend/src/validators/createWorkOrderValidator.ts
@@ -73,17 +73,17 @@ export const createWorkOrderValidator = z
       .trim()
       .datetime({ message: 'dueDate must be an ISO 8601 date string' })
       .optional(),
-    assignedTo: z
-      .string({ invalid_type_error: 'assignedTo must be a string' })
+    assigneeId: z
+      .string({ invalid_type_error: 'assigneeId must be a string' })
       .trim()
-      .min(1, 'assignedTo is required')
+      .min(1, 'assigneeId is required')
       .transform((value, ctx) => {
         try {
           return normalizeToObjectIdString(value);
         } catch (error) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
-            message: 'Invalid assignedTo',
+            message: 'Invalid assigneeId',
           });
           return z.NEVER;
         }

--- a/backend/src/validators/workOrderValidators.ts
+++ b/backend/src/validators/workOrderValidators.ts
@@ -59,7 +59,7 @@ export const createWorkOrderValidator = z
     status: statusEnum.optional(),
     priority: priorityEnum.optional(),
     assetId: objectIdSchema.optional(),
-    assignedTo: z.union([objectIdSchema, z.null()]).optional(),
+    assigneeId: z.union([objectIdSchema, z.null()]).optional(),
     category: z
       .string({ invalid_type_error: 'Category must be a string' })
       .trim()


### PR DESCRIPTION
## Summary
- rename the Prisma work order assignee column to `assigneeId` and update its relation alias
- update validators, controllers, routes, and seeds to read and write the new assignee field
- regenerate the Prisma client so the backend code compiles against the renamed field

## Testing
- npm run db:generate
- timeout 15s /bin/sh -c 'DATABASE_URL="mongodb://localhost:27017/test" npx tsx src/index.ts'

------
https://chatgpt.com/codex/tasks/task_e_68dd3e3987548323b7133f3039ab45d1