### PR TITLE
Guard temporary filter sync

### DIFF
--- a/frontend/src/pages/WorkOrders.jsx
+++ b/frontend/src/pages/WorkOrders.jsx
@@ -51,9 +51,17 @@ export function WorkOrders() {
   const [showCreate, setShowCreate] = useState(false);
 
   useEffect(() => {
-    if (isFiltersOpen) {
-      setTempFilters({ ...advancedFilters });
+    if (!isFiltersOpen) {
+      return;
     }
+
+    setTempFilters((previous) => {
+      const hasChanges = Object.keys(advancedFilters).some((key) => {
+        return previous?.[key] !== advancedFilters[key];
+      });
+
+      return hasChanges ? { ...advancedFilters } : previous;
+    });
   }, [isFiltersOpen, advancedFilters]);
 
   const queryClient = useQueryClient();


### PR DESCRIPTION
## Summary
- prevent the advanced filter synchronization effect from running when values are unchanged
- avoid unnecessary temp filter updates by using the setter callback guard

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd8b2f26108323aa88e8b53828f34a