### PR TITLE
Align work orders endpoint with API base

### DIFF
--- a/frontend/src/pages/WorkOrders.jsx
+++ b/frontend/src/pages/WorkOrders.jsx
@@ -87,7 +87,7 @@ export function WorkOrders() {
       if (advancedFilters.to) params.set('to', advancedFilters.to);
 
 
-      const result = await api.get(`/api/work-orders?${params}`);
+      const result = await api.get(`/work-orders?${params}`);
       return result?.data ?? result;
     },
   });


### PR DESCRIPTION
## Summary
- update the work orders query to hit `/work-orders` so it matches the API base URL
- confirm the existing `invalidateQueries` target key remains `['work-orders']`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd8b2f4aa08323a5d61604a5931567