### PR TITLE
Fix WorkOrderForm reset handling

### DIFF
--- a/frontend/src/components/work-orders/WorkOrderForm.jsx
+++ b/frontend/src/components/work-orders/WorkOrderForm.jsx
@@ -76,7 +76,7 @@ export function WorkOrderForm({ onClose, onSuccess, defaultValues }) {
 
   });
 
-  const { register, handleSubmit, setError, setValue, watch, formState } = form;
+  const { register, handleSubmit, reset, setError, setValue, watch, formState } = form;
   const { errors, isSubmitting } = formState;
 
   const attachments = watch('attachments') || [];


### PR DESCRIPTION
## Summary
- include the reset function from useForm so the submit handler can clear the form without errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd8b30c74c8323a11a29a01460c1c4