### PR TITLE
Include username in login request

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -14,6 +14,7 @@ export interface User {
 
 interface LoginRequest {
   email: string;
+  username: string;
   password: string;
 }
 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -22,7 +22,7 @@ export default function Login() {
     event.preventDefault();
     setFormError('');
     try {
-      await login({ email, password });
+      await login({ email, username: email, password });
       navigate('/');
     } catch (err) {
       setFormError(err instanceof Error ? err.message : 'Unable to sign in.');


### PR DESCRIPTION
## Summary
- update the auth login request type so the payload includes the username expected by the backend
- send the username derived from the email when submitting the login form

## Testing
- curl -i -X POST http://localhost:5010/api/auth/login -H 'Content-Type: application/json' -d '{"username":"admin@demo.com","password":"Admin@123","email":"admin@demo.com"}'

------
https://chatgpt.com/codex/tasks/task_e_68ddacd3cf308323b314657e129b0281