### PR TITLE
Add nested fallback route for protected pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,6 +47,7 @@ export default function App() {
               <Route path="documents" element={<Documents />} />
               <Route path="analytics" element={<Analytics />} />
               <Route path="settings" element={<Settings />} />
+              <Route path="*" element={<NotFound />} />
             </Route>
             <Route path="*" element={<NotFound />} />
           </Routes>


### PR DESCRIPTION
## Summary
- add a catch-all child route within the protected root route so unknown dashboard paths display the NotFound screen

## Testing
- `npm test -- --run` *(fails: backend tests depend on prisma client setup and validation expectations)*

------
https://chatgpt.com/codex/tasks/task_e_68ddacd464348323a1f47f057fcd588f