### PR TITLE
Align auth API contract and add tests

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -4,18 +4,144 @@ import { URL } from 'url';
 import { loadEnv } from './config/env';
 import { connectMongo } from './config/mongo';
 
+type AuthUser = {
+  id: string;
+  tenantId: string;
+  email: string;
+  name: string;
+  role: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+const activeSessions = new Map<string, AuthUser>();
+
+function toBase64Url(value: string): string {
+  return Buffer.from(value, 'utf8')
+    .toString('base64')
+    .replace(/\+/gu, '-')
+    .replace(/\//gu, '_')
+    .replace(/=+$/u, '');
+}
+
+function buildUserProfile(identifier: string): AuthUser {
+  const email = identifier.includes('@') ? identifier.toLowerCase() : `${identifier.toLowerCase()}@example.com`;
+  const namePart = email.split('@')[0] ?? 'user';
+  const name = namePart
+    .split(/[._\-\s]+/u)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ') || 'Demo User';
+  const now = new Date().toISOString();
+
+  return {
+    id: `user-${toBase64Url(email).slice(0, 16)}`,
+    tenantId: 'tenant-demo',
+    email,
+    name,
+    role: 'user',
+    createdAt: now,
+    updatedAt: now,
+  } satisfies AuthUser;
+}
+
+function decodeToken(token: string): string | null {
+  try {
+    const decoded = Buffer.from(token, 'base64').toString('utf8');
+    const [identifier] = decoded.split(':');
+    return identifier?.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+function buildError(status: number, message: string, details?: unknown) {
+  return {
+    status,
+    body: {
+      data: null,
+      error: {
+        code: status,
+        message,
+        details,
+      },
+    },
+  };
+}
+
 async function handleLogin(body: unknown): Promise<{ status: number; body: unknown }> {
   const payload = (body as Record<string, unknown>) || {};
-  const username = typeof payload['username'] === 'string' ? (payload['username'] as string) : '';
-  const password = typeof payload['password'] === 'string' ? (payload['password'] as string) : '';
+  const identifierRaw =
+    (typeof payload['email'] === 'string' ? payload['email'] : undefined) ??
+    (typeof payload['username'] === 'string' ? payload['username'] : undefined) ??
+    '';
+  const identifier = identifierRaw.trim();
+  const password = typeof payload['password'] === 'string' ? payload['password'].trim() : '';
 
-  if (!username || !password) {
-    return { status: 400, body: { error: { code: 400, message: 'Missing username or password' } } };
+  if (!identifier || !password) {
+    return buildError(400, 'Missing email/username or password');
   }
 
-  // Placeholder authentication: replace with real logic (DB lookup, hashing, etc.)
-  const token = Buffer.from(`${username}:${password}`).toString('base64');
-  return { status: 200, body: { token } };
+  const token = Buffer.from(`${identifier}:${password}`).toString('base64');
+  const user = buildUserProfile(identifier);
+
+  activeSessions.set(token, user);
+
+  return {
+    status: 200,
+    body: {
+      data: {
+        token,
+        user,
+      },
+      error: null,
+    },
+  };
+}
+
+function handleAuthMe(token: string | null) {
+  if (!token) {
+    return buildError(401, 'Unauthorized');
+  }
+
+  const sessionUser = activeSessions.get(token);
+
+  if (sessionUser) {
+    return {
+      status: 200,
+      body: { data: sessionUser, error: null },
+    };
+  }
+
+  const identifier = decodeToken(token);
+
+  if (!identifier) {
+    return buildError(401, 'Unauthorized');
+  }
+
+  const user = buildUserProfile(identifier);
+  activeSessions.set(token, user);
+
+  return {
+    status: 200,
+    body: { data: user, error: null },
+  };
+}
+
+function extractBearerToken(req: http.IncomingMessage): string | null {
+  const header = req.headers['authorization'];
+
+  if (typeof header !== 'string') {
+    return null;
+  }
+
+  const [scheme, value] = header.split(' ');
+
+  if (!scheme || !value || scheme.toLowerCase() !== 'bearer') {
+    return null;
+  }
+
+  return value.trim() || null;
 }
 
 loadEnv();
@@ -98,19 +224,39 @@ export async function start(): Promise<void> {
         return;
       }
 
-      if (url.pathname.startsWith('/api')) {
-        sendJson(res, 404, { error: { code: 404, message: 'API route not found' } });
+      if (url.pathname === '/api/auth/me' && req.method === 'GET') {
+        const token = extractBearerToken(req);
+        const result = handleAuthMe(token);
+        sendJson(res, result.status, result.body);
         return;
       }
 
-      sendJson(res, 404, { error: { code: 404, message: 'Route not found' } });
+      if (url.pathname === '/api/auth/logout' && req.method === 'POST') {
+        const token = extractBearerToken(req);
+        if (token) {
+          activeSessions.delete(token);
+        }
+
+        sendJson(res, 200, { data: { success: true }, error: null });
+        return;
+      }
+
+      if (url.pathname.startsWith('/api')) {
+        const result = buildError(404, 'API route not found');
+        sendJson(res, result.status, result.body);
+        return;
+      }
+
+      const result = buildError(404, 'Route not found');
+      sendJson(res, result.status, result.body);
     } catch (error) {
       if (NODE_ENV !== 'production') {
         console.error('[server]', error);
       }
       const message = error instanceof Error ? error.message : 'Internal Server Error';
       const status = message === 'Invalid JSON payload' || message === 'Payload too large' ? 400 : 500;
-      sendJson(res, status, { error: { code: status, message } });
+      const result = buildError(status, message);
+      sendJson(res, result.status, result.body);
     }
   });
 

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -1,0 +1,98 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { User } from './useAuth';
+import { api } from '../lib/api';
+
+function createLocalStorageMock(): Storage {
+  const store = new Map<string, string>();
+
+  return {
+    get length() {
+      return store.size;
+    },
+    clear: () => {
+      store.clear();
+    },
+    getItem: (key: string) => {
+      return store.has(key) ? store.get(key)! : null;
+    },
+    key: (index: number) => {
+      return Array.from(store.keys())[index] ?? null;
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+  } as Storage;
+}
+
+let useAuthHook: typeof import('./useAuth').useAuth;
+let storage: Storage;
+
+beforeAll(async () => {
+  storage = createLocalStorageMock();
+
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: storage,
+    writable: false,
+  });
+
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: { localStorage: storage } as Window & typeof globalThis,
+    writable: false,
+  });
+
+  const module = await import('./useAuth');
+  useAuthHook = module.useAuth;
+});
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  storage.clear();
+  useAuthHook.setState({
+    user: null,
+    isAuthenticated: false,
+    isLoading: false,
+    error: null,
+  });
+});
+
+describe('useAuth store', () => {
+  it('marks the user as authenticated after successful login', async () => {
+    const mockUser: User = {
+      id: 'user-1',
+      tenantId: 'tenant-1',
+      email: 'john@example.com',
+      name: 'John Smith',
+      role: 'admin',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    const postSpy = vi.spyOn(api, 'post').mockResolvedValue({
+      token: 'test-token',
+      user: mockUser,
+    });
+    const getSpy = vi.spyOn(api, 'get').mockResolvedValue(mockUser);
+
+    await useAuthHook.getState().login({ email: mockUser.email, password: 'secret' });
+
+    expect(postSpy).toHaveBeenCalledWith('/auth/login', {
+      email: mockUser.email,
+      password: 'secret',
+    });
+    expect(getSpy).toHaveBeenCalledWith('/auth/me');
+
+    const state = useAuthHook.getState();
+    expect(state.isAuthenticated).toBe(true);
+    expect(state.user).toMatchObject({
+      id: mockUser.id,
+      email: mockUser.email,
+      name: mockUser.name,
+    });
+    expect(state.error).toBeNull();
+  });
+});

--- a/src/pages/Dashboard.test.tsx
+++ b/src/pages/Dashboard.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import Dashboard from './Dashboard';
+
+describe('Dashboard page', () => {
+  it('renders without throwing', () => {
+    expect(() => renderToString(<Dashboard />)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- normalize ApiClient response handling so bare JSON payloads and `{ data, error }` envelopes both work
- expand the lightweight backend auth handlers to return structured results, expose `/api/auth/me`, and keep simple in-memory sessions
- add regression tests to verify the auth hook marks users authenticated and that the dashboard page renders without crashing

## Testing
- pnpm test src/hooks/useAuth.test.ts src/pages/Dashboard.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68ddacd48d748323b92a63884ba9eceb