### PR TITLE
refactor: centralize toaster in layout

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,7 +2,6 @@ import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import { Layout } from './components/Layout';
-import { Toaster } from './components/ui/toaster';
 import { AuthProvider, useAuth } from './hooks/useAuth';
 import { Dashboard } from './pages/Dashboard';
 import { WorkOrders } from './pages/WorkOrders';
@@ -38,7 +37,6 @@ function App() {
     <QueryClientProvider client={queryClient}>
       <AuthProvider>
         <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
-          <Toaster />
           <Routes>
             <Route path="/login" element={<Login />} />
             <Route

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -2,7 +2,7 @@ import { Outlet } from 'react-router-dom';
 
 import { Header } from './Header';
 import { Sidebar } from './Sidebar';
-import { ToastViewport } from './ui/toast';
+import { Toaster } from '@/components/ui/toaster';
 
 export function Layout({ children }) {
   return (
@@ -12,9 +12,9 @@ export function Layout({ children }) {
         <Sidebar />
         <main className="flex-1 p-6">
           {children || <Outlet />}
+          <Toaster />
         </main>
       </div>
-      <ToastViewport />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace the toast viewport in the layout with the new Toaster component
- remove the duplicate Toaster provider from the app router so it mounts once

## Testing
- rg "<Toaster" frontend/src

------
https://chatgpt.com/codex/tasks/task_e_68de777fbd3c8323bd20bd5ed6b6082f