### PR TITLE
Guard layout storage access for SSR

### DIFF
--- a/src/components/layout/Layout.test.tsx
+++ b/src/components/layout/Layout.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import { Layout } from './Layout';
+
+vi.mock('./Header', () => ({
+  Header: ({ onToggleSidebar }: { onToggleSidebar: () => void }) => (
+    <button type="button" onClick={onToggleSidebar}>
+      Toggle
+    </button>
+  )
+}));
+
+vi.mock('./Sidebar', () => ({
+  Sidebar: ({ onCollapseToggle }: { onCollapseToggle: () => void }) => (
+    <button type="button" onClick={onCollapseToggle}>
+      Sidebar
+    </button>
+  ),
+  navItems: []
+}));
+
+vi.mock('./MobileNav', () => ({
+  MobileNav: () => <div>MobileNav</div>
+}));
+
+describe('Layout component', () => {
+  it('renders without window or localStorage', () => {
+    const globalAny = globalThis as any;
+    const originalWindow = globalAny.window;
+    const originalLocalStorage = globalAny.localStorage;
+
+    globalAny.window = undefined;
+    globalAny.localStorage = undefined;
+
+    try {
+      expect(() => renderToString(<Layout />)).not.toThrow();
+    } finally {
+      if (originalWindow === undefined) {
+        delete globalAny.window;
+      } else {
+        globalAny.window = originalWindow;
+      }
+
+      if (originalLocalStorage === undefined) {
+        delete globalAny.localStorage;
+      } else {
+        globalAny.localStorage = originalLocalStorage;
+      }
+    }
+  });
+});

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -9,23 +9,47 @@ const SIDEBAR_STORAGE_KEY = 'wp3.sidebar.collapsed';
 
 export function Layout() {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {
-    const stored = localStorage.getItem(SIDEBAR_STORAGE_KEY);
-    return stored ? JSON.parse(stored) : false;
+    if (typeof window === 'undefined') {
+      return false;
+    }
+
+    try {
+      const stored = window.localStorage.getItem(SIDEBAR_STORAGE_KEY);
+      return stored ? JSON.parse(stored) : false;
+    } catch (error) {
+      return false;
+    }
   });
   
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
 
   useEffect(() => {
-    localStorage.setItem(SIDEBAR_STORAGE_KEY, JSON.stringify(sidebarCollapsed));
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    try {
+      window.localStorage.setItem(
+        SIDEBAR_STORAGE_KEY,
+        JSON.stringify(sidebarCollapsed),
+      );
+    } catch (error) {
+      // Ignore storage write errors (e.g., unavailable localStorage)
+    }
   }, [sidebarCollapsed]);
 
   const handleToggleSidebar = () => {
+    if (typeof window === 'undefined') {
+      setSidebarCollapsed((prev) => !prev);
+      return;
+    }
+
     // On mobile, toggle mobile nav
     if (window.innerWidth < 1024) {
-      setMobileNavOpen(!mobileNavOpen);
+      setMobileNavOpen((prev) => !prev);
     } else {
       // On desktop, toggle sidebar collapse
-      setSidebarCollapsed(!sidebarCollapsed);
+      setSidebarCollapsed((prev) => !prev);
     }
   };
 


### PR DESCRIPTION
## Summary
- guard layout sidebar persistence when window/localStorage are unavailable
- treat non-browser contexts as desktop when toggling the sidebar
- add a regression test ensuring Layout renders without window/localStorage

## Testing
- npm run test -- Layout

------
https://chatgpt.com/codex/tasks/task_e_68ded16f23388323aaf6928d8626822f