### PR TITLE
Fix login hook to handle nested response data

### DIFF
--- a/frontend/src/hooks/useAuth.jsx
+++ b/frontend/src/hooks/useAuth.jsx
@@ -36,7 +36,8 @@ export function AuthProvider({ children }) {
 
     try {
       const res = await api.post('/auth/login', { email, password });
-      const { token: nextToken, user: nextUser } = res?.data ?? {};
+      const { token: nextToken, user: nextUser } =
+        res?.data?.data ?? res?.data ?? {};
 
       if (!nextToken) {
         throw new Error('Missing token in login response');


### PR DESCRIPTION
## Summary
- ensure the auth hook reads token and user from nested API responses while keeping the existing normalisation and persistence behaviour

## Testing
- npm run --prefix backend dev *(fails: tsx command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68deea1e1ed0832387a107b430418f26