### PR TITLE
fix(frontend): ensure auth header overrides

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,7 +30,7 @@
         "autoprefixer": "^10.4.14",
         "postcss": "^8.4.21",
         "tailwindcss": "^3.2.7",
-        "typescript": "^4.9.5",
+        "typescript": "^5.9.3",
         "vite": "^7.1.6"
       }
     },
@@ -3923,9 +3923,9 @@
       "license": "0BSD"
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3933,7 +3933,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/update-browserslist-db": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,7 @@
     "autoprefixer": "^10.4.14",
     "postcss": "^8.4.21",
     "tailwindcss": "^3.2.7",
-    "typescript": "^4.9.5",
+    "typescript": "^5.9.3",
     "vite": "^7.1.6"
   },
   "overrides": {

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -17,20 +17,28 @@ function readToken() {
   }
 }
 
-function setHeader(headers, key, value) {
+function setHeader(headers, key, value, options = {}) {
   if (!headers || value == null) {
     return;
   }
 
+  const { override = true } = options;
+
   if (typeof headers.set === 'function') {
-    if (!headers.has || !headers.has(key)) {
+    if (override || !headers.has || !headers.has(key)) {
       headers.set(key, value);
     }
     return;
   }
 
-  if (!headers[key]) {
-    headers[key] = value;
+  const existingKey =
+    typeof headers === 'object' && headers !== null
+      ? Object.keys(headers).find((headerKey) => headerKey.toLowerCase() === key.toLowerCase())
+      : undefined;
+
+  if (override || typeof existingKey === 'undefined') {
+    const targetKey = typeof existingKey === 'string' ? existingKey : key;
+    headers[targetKey] = value;
   }
 }
 
@@ -43,7 +51,7 @@ api.interceptors.request.use((config) => {
   const nextConfig = config;
   nextConfig.headers = nextConfig.headers ?? {};
 
-  setHeader(nextConfig.headers, 'Content-Type', 'application/json');
+  setHeader(nextConfig.headers, 'Content-Type', 'application/json', { override: false });
 
   const token = readToken();
   if (token) {

--- a/frontend/src/types/class-variance-authority.d.ts
+++ b/frontend/src/types/class-variance-authority.d.ts
@@ -1,0 +1,25 @@
+declare module 'class-variance-authority' {
+  type VariantRecord = Record<string, Record<string, string>>;
+
+  interface CVAConfig<V extends VariantRecord = VariantRecord> {
+    variants?: V;
+    defaultVariants?: Partial<{ [K in keyof V]: keyof V[K] }>;
+  }
+
+  type CVAProps<V extends VariantRecord> = {
+    className?: string;
+  } & {
+    [K in keyof V]?: keyof V[K];
+  };
+
+  export type VariantProps<T> = T extends (props?: infer P) => any
+    ? NonNullable<P>
+    : never;
+
+  export function cva<V extends VariantRecord = VariantRecord>(
+    base?: string,
+    config?: CVAConfig<V>,
+  ): (props?: CVAProps<V>) => string;
+
+  export default cva;
+}


### PR DESCRIPTION
## Summary
- update the shared setHeader helper so Authorization is always refreshed while allowing custom Content-Type overrides
- upgrade the frontend TypeScript toolchain and add a local declaration for the class-variance-authority shim so type checking succeeds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfad06b1408323aa2a372d3374c08f