### PR TITLE
Adjust auth middleware token failure response

### DIFF
--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -90,7 +90,7 @@ export function authenticateToken(req: AuthRequest, res: Response, next: NextFun
 
   jwt.verify(token, getJwtSecret(), async (err: any, decoded: any) => {
     if (err) {
-      return fail(res, 403, 'Invalid or expired token');
+      return fail(res, 401, 'Invalid or expired token');
     }
 
     try {
@@ -106,7 +106,7 @@ export function authenticateToken(req: AuthRequest, res: Response, next: NextFun
       });
 
       if (!user) {
-        return fail(res, 403, 'User not found');
+        return fail(res, 401, 'Invalid or expired token');
       }
 
       const userSiteId = (user as { siteId?: string | null }).siteId ?? null;


### PR DESCRIPTION
## Summary
- update authenticateToken to return 401 with a consistent message when JWT verification fails or the decoded user is missing

## Testing
- pnpm --dir backend test *(fails: existing Vitest suite cannot load certain dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfcd215ec48323a7c5612f871ea173