### PR TITLE
Remove Radix toast override from frontend package config

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,7 +42,6 @@
     "@radix-ui/react-presence": "^1.0.1",
     "@radix-ui/react-primitive": "^1.0.3",
     "@radix-ui/react-slot": "^1.0.2",
-    "@radix-ui/react-toast": "^1.1.5",
     "@radix-ui/react-use-callback-ref": "^1.0.1",
     "@radix-ui/react-use-controllable-state": "^1.0.1",
     "@radix-ui/react-use-effect-event": "^0.0.2",


### PR DESCRIPTION
## Summary
- remove the @radix-ui/react-toast override from the frontend package overrides since it matches the direct dependency version

## Testing
- npm install (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68dfd88be2a08323984dce6fa049a365