### PR TITLE
chore: align radix overrides

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
-        "@radix-ui/react-toast": "1.1.5",
+        "@radix-ui/react-toast": "^1.1.5",
         "@tanstack/react-query": "^4.41.0",
         "axios": "^1.12.2",
         "concurrently": "^9.2.1",
@@ -1083,17 +1083,16 @@
       }
     },
     "node_modules/@radix-ui/react-slot": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.2.tgz",
-      "integrity": "sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-compose-refs": "1.0.1"
+        "@radix-ui/react-compose-refs": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0"
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
       },
       "peerDependenciesMeta": {
         "@types/react": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@radix-ui/react-toast": "1.1.5",
+    "@radix-ui/react-toast": "^1.1.5",
     "@hookform/resolvers": "^5.2.2",
     "@tanstack/react-query": "^4.41.0",
     "axios": "^1.12.2",
@@ -41,12 +41,12 @@
     "@radix-ui/react-portal": "^1.0.4",
     "@radix-ui/react-presence": "^1.0.1",
     "@radix-ui/react-primitive": "^1.0.3",
-    "@radix-ui/react-slot": "^1.0.2",
+    "@radix-ui/react-slot": "^1.0.3",
     "@radix-ui/react-use-callback-ref": "^1.0.1",
     "@radix-ui/react-use-controllable-state": "^1.0.1",
-    "@radix-ui/react-use-effect-event": "^0.0.2",
     "@radix-ui/react-use-escape-keydown": "^1.0.3",
     "@radix-ui/react-use-layout-effect": "^1.0.1",
-    "@radix-ui/react-visually-hidden": "^1.0.3"
+    "@radix-ui/react-visually-hidden": "^1.0.3",
+    "@radix-ui/react-toast": "^1.1.5"
   }
 }


### PR DESCRIPTION
## Summary
- bump the Radix slot override to the latest 1.x release and remove the unused effect-event override
- add the missing override for @radix-ui/react-toast and align its dependency range
- refresh the frontend lockfile via npm install and npm dedupe to capture the new Radix graph

## Testing
- npm install
- npm dedupe

------
https://chatgpt.com/codex/tasks/task_e_68dfdd82531083239940a34c40224776