### PR TITLE
Implement inventory models, APIs, and UI integration

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -34,6 +34,7 @@
         "@types/jsonwebtoken": "^9.0.5",
         "@types/node": "^20.19.0",
         "@types/nodemailer": "^6.4.14",
+        "@types/supertest": "^2.0.16",
         "@types/swagger-jsdoc": "^6.0.4",
         "@types/swagger-ui-express": "^4.1.6",
         "@typescript-eslint/eslint-plugin": "^6.14.0",
@@ -1865,7 +1866,7 @@
       "version": "6.16.3",
       "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.16.3.tgz",
       "integrity": "sha512-VlsLnG4oOuKGGMToEeVaRhoTBZu5H3q51jTQXb/diRags3WV0+BQK5MolJTtP6G7COlzoXmWeS11rNBtvg+qFQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "c12": "3.1.0",
@@ -1893,7 +1894,7 @@
       "version": "6.16.3",
       "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.16.3.tgz",
       "integrity": "sha512-b+Rl4nzQDcoqe6RIpSHv8f5lLnwdDGvXhHjGDiokObguAAv/O1KaX1Oc69mBW/GFWKQpCkOraobLjU6s1h8HGg==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1907,14 +1908,14 @@
       "version": "6.16.1-1.bb420e667c1820a8c05a38023385f6cc7ef8e83a",
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.16.1-1.bb420e667c1820a8c05a38023385f6cc7ef8e83a.tgz",
       "integrity": "sha512-fftRmosBex48Ph1v2ll1FrPpirwtPZpNkE5CDCY1Lw2SD2ctyrLlVlHiuxDAAlALwWBOkPbAll4+EaqdGuMhJw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
       "version": "6.16.3",
       "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.16.3.tgz",
       "integrity": "sha512-bUoRIkVaI+CCaVGrSfcKev0/Mk4ateubqWqGZvQ9uCqFv2ENwWIR3OeNuGin96nZn5+SkebcD7RGgKr/+mJelw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "6.16.3",
@@ -1926,7 +1927,7 @@
       "version": "6.16.3",
       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.16.3.tgz",
       "integrity": "sha512-X1LxiFXinJ4iQehrodGp0f66Dv6cDL0GbRlcCoLtSu6f4Wi+hgo7eND/afIs5029GQLgNWKZ46vn8hjyXTsHLA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "6.16.3"
@@ -2875,7 +2876,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
       "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tediousjs/connection-string": {
@@ -2950,6 +2951,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/cors": {
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
@@ -3023,6 +3031,13 @@
         "@types/ms": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/mime": {
       "version": "1.3.5",
@@ -3109,6 +3124,29 @@
         "@types/http-errors": "*",
         "@types/node": "*",
         "@types/send": "*"
+      }
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-2.0.16.tgz",
+      "integrity": "sha512-6c2ogktZ06tr2ENoZivgm7YnprnhYE4ZoXGMY+oA7IuAf17M8FWvujXZGmxLv8y0PTyts4x5A+erSwVUFA8XSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/superagent": "*"
       }
     },
     "node_modules/@types/swagger-jsdoc": {
@@ -3953,7 +3991,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/c12/-/c12-3.1.0.tgz",
       "integrity": "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.3",
@@ -3982,7 +4020,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -3998,7 +4036,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -4180,7 +4218,7 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
       "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "consola": "^3.2.3"
@@ -4264,14 +4302,14 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
       "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/consola": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
       "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
@@ -4424,7 +4462,7 @@
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
       "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=16.0.0"
@@ -4491,7 +4529,7 @@
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
       "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/delayed-stream": {
@@ -4526,7 +4564,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
       "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/destroy": {
@@ -4640,7 +4678,7 @@
       "version": "3.16.12",
       "resolved": "https://registry.npmjs.org/effect/-/effect-3.16.12.tgz",
       "integrity": "sha512-N39iBk0K71F9nb442TLbTkjl24FLUzuvx2i1I2RsEAQsdAdUTuUoW0vlfUXgkMTUOnYqKnWcFfqw4hK4Pw27hg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
@@ -4651,7 +4689,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
       "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -5087,14 +5125,14 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
       "integrity": "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-check": {
       "version": "3.23.2",
       "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
       "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -5505,7 +5543,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
       "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "citty": "^0.1.6",
@@ -6052,7 +6090,7 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.0.tgz",
       "integrity": "sha512-VXe6RjJkBPj0ohtqaO8vSWP3ZhAKo66fKrFNCll4BTcwljPLz03pCbaNKfzGP5MbrCYcbJ7v0nOYYwUzTEIdXQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -6786,7 +6824,7 @@
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
       "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-gyp-build-optional-packages": {
@@ -6903,7 +6941,7 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.2.tgz",
       "integrity": "sha512-7eM+hpOtrKrBDCh7Ypu2lJ9Z7PNZBdi/8AT3AX8xoCj43BBVHD0hPSTEvMtkMpfs8FCqBGhxB+uToIQimA111g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "citty": "^0.1.6",
@@ -6923,7 +6961,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
       "integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/object-assign": {
@@ -6951,7 +6989,7 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/on-finished": {
@@ -6992,13 +7030,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/openapi-types": {
-      "version": "12.1.3",
-      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
-      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -7131,7 +7162,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pathval": {
@@ -7155,7 +7186,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
       "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -7251,7 +7282,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
       "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "confbox": "^0.2.2",
@@ -7327,7 +7358,7 @@
       "version": "6.16.3",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.16.3.tgz",
       "integrity": "sha512-4tJq3KB9WRshH5+QmzOLV54YMkNlKOtLKaSdvraI5kC/axF47HuOw6zDM8xrxJ6s9o2WodY654On4XKkrobQdQ==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7400,7 +7431,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
       "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -7495,7 +7526,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
       "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "defu": "^6.1.4",
@@ -8672,7 +8703,7 @@
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -9250,28 +9281,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/vite-node/node_modules/tsx": {
-      "version": "4.20.6",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
-      "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "esbuild": "~0.25.0",
-        "get-tsconfig": "^4.7.5"
-      },
-      "bin": {
-        "tsx": "dist/cli.mjs"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      }
-    },
     "node_modules/vite-node/node_modules/vite": {
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.7.tgz",
@@ -9345,21 +9354,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite-node/node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
       }
     },
     "node_modules/vitest": {
@@ -9909,28 +9903,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/vitest/node_modules/tsx": {
-      "version": "4.20.6",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
-      "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "esbuild": "~0.25.0",
-        "get-tsconfig": "^4.7.5"
-      },
-      "bin": {
-        "tsx": "dist/cli.mjs"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      }
-    },
     "node_modules/vitest/node_modules/vite": {
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.7.tgz",
@@ -10004,21 +9976,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vitest/node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
       }
     },
     "node_modules/web-encoding": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -44,6 +44,7 @@
     "@types/jsonwebtoken": "^9.0.5",
     "@types/node": "^20.19.0",
     "@types/nodemailer": "^6.4.14",
+    "@types/supertest": "^2.0.16",
     "@types/swagger-jsdoc": "^6.0.4",
     "@types/swagger-ui-express": "^4.1.6",
     "@typescript-eslint/eslint-plugin": "^6.14.0",

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -12,9 +12,15 @@ model Tenant {
   name String
   slug String @unique
 
-  users      User[]
-  assets     Asset[]
-  workOrders WorkOrder[]
+  users         User[]
+  assets        Asset[]
+  workOrders    WorkOrder[]
+  parts         Part[]
+  warehouses    Warehouse[]
+  stockLevels   StockLevel[]
+  vendors       Vendor[]
+  purchaseOrders PurchaseOrder[]
+  downtimeLogs  DowntimeLog[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -155,23 +161,140 @@ model DowntimeLog {
   @@index([tenantId, assetId], map: "downtime_tenant_asset_idx")
 }
 
-model Part {
-  id        String @id @map("_id") @default(auto()) @db.ObjectId
-  tenantId  String @map("tenant_id") @db.ObjectId
-  siteId    String? @map("site_id") @db.ObjectId
-  name      String
-  sku       String? @unique
-  onHand    Int     @map("on_hand") @default(0)
-  minLevel  Int     @map("min_level") @default(0)
-  cost      Float?  @map("cost")
-  vendor    String?
+enum PurchaseOrderStatus {
+  draft
+  issued
+  received
+  closed
+}
 
-  tenant Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+model Vendor {
+  id        String   @id @map("_id") @default(auto()) @db.ObjectId
+  tenantId  String   @map("tenant_id") @db.ObjectId
+  name      String
+  contact   Json?
+
+  tenant         Tenant          @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  parts          Part[]          @relation("PreferredVendor")
+  purchaseOrders PurchaseOrder[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@map("vendors")
+  @@index([tenantId])
+  @@index([tenantId, name])
+}
+
+model Warehouse {
+  id         String  @id @map("_id") @default(auto()) @db.ObjectId
+  tenantId   String  @map("tenant_id") @db.ObjectId
+  name       String
+  code       String?
+  location   String?
+  isDefault  Boolean @map("is_default") @default(false)
+
+  tenant      Tenant       @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  stockLevels StockLevel[]
+  purchaseLines PurchaseOrderLine[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@map("warehouses")
+  @@index([tenantId])
+  @@unique([tenantId, code], map: "warehouse_tenant_code_unique")
+}
+
+model Part {
+  id               String  @id @map("_id") @default(auto()) @db.ObjectId
+  tenantId         String  @map("tenant_id") @db.ObjectId
+  sku              String
+  name             String
+  description      String?
+  unitOfMeasure    String? @map("unit_of_measure")
+  cost             Float?  @map("unit_cost")
+  defaultMinLevel  Int     @map("default_min_level") @default(0)
+  defaultMaxLevel  Int     @map("default_max_level") @default(0)
+  preferredVendorId String? @map("preferred_vendor_id") @db.ObjectId
+
+  tenant          Tenant             @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  preferredVendor Vendor?            @relation("PreferredVendor", fields: [preferredVendorId], references: [id])
+  stockLevels     StockLevel[]
+  purchaseLines   PurchaseOrderLine[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
   @@map("parts")
   @@index([tenantId])
-  @@index([minLevel, onHand, tenantId], map: "parts_min_onhand_tenant_idx")
+  @@unique([tenantId, sku], map: "parts_tenant_sku_unique")
+}
+
+model StockLevel {
+  id          String     @id @map("_id") @default(auto()) @db.ObjectId
+  tenantId    String     @map("tenant_id") @db.ObjectId
+  partId      String     @map("part_id") @db.ObjectId
+  warehouseId String     @map("warehouse_id") @db.ObjectId
+  onHand      Int        @map("on_hand") @default(0)
+  onOrder     Int        @map("on_order") @default(0)
+  allocated   Int        @default(0)
+  minLevel    Int        @map("min_level") @default(0)
+  maxLevel    Int        @map("max_level") @default(0)
+
+  tenant    Tenant    @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  part      Part      @relation(fields: [partId], references: [id], onDelete: Cascade)
+  warehouse Warehouse @relation(fields: [warehouseId], references: [id], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@map("stock_levels")
+  @@unique([partId, warehouseId], map: "stock_levels_part_wh_unique")
+  @@index([tenantId, partId])
+}
+
+model PurchaseOrder {
+  id         String               @id @map("_id") @default(auto()) @db.ObjectId
+  tenantId   String               @map("tenant_id") @db.ObjectId
+  vendorId   String               @map("vendor_id") @db.ObjectId
+  status     PurchaseOrderStatus  @default(draft)
+  number     String?
+  notes      String?
+  orderedAt  DateTime?            @map("ordered_at")
+  receivedAt DateTime?            @map("received_at")
+
+  tenant Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  vendor Vendor @relation(fields: [vendorId], references: [id], onDelete: Cascade)
+  lines  PurchaseOrderLine[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@map("purchase_orders")
+  @@index([tenantId])
+  @@index([tenantId, status])
+}
+
+model PurchaseOrderLine {
+  id              String        @id @map("_id") @default(auto()) @db.ObjectId
+  tenantId        String        @map("tenant_id") @db.ObjectId
+  purchaseOrderId String        @map("purchase_order_id") @db.ObjectId
+  partId          String        @map("part_id") @db.ObjectId
+  warehouseId     String?       @map("warehouse_id") @db.ObjectId
+  quantity        Int           @default(0)
+  receivedQty     Int           @map("received_qty") @default(0)
+  unitCost        Float?        @map("unit_cost")
+
+  purchaseOrder PurchaseOrder @relation(fields: [purchaseOrderId], references: [id], onDelete: Cascade)
+  part          Part          @relation(fields: [partId], references: [id], onDelete: Cascade)
+  warehouse     Warehouse?    @relation(fields: [warehouseId], references: [id])
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@map("purchase_order_lines")
+  @@index([tenantId])
+  @@index([purchaseOrderId])
+  @@index([partId])
 }

--- a/backend/src/controllers/workOrderController.ts
+++ b/backend/src/controllers/workOrderController.ts
@@ -44,12 +44,20 @@ function serializeWorkOrder(workOrder: {
   assigneeId: string | null;
   dueDate: Date | null;
   category: string | null;
-  attachments: Prisma.JsonValue | null;
+  attachments: string[];
   createdAt: Date;
   updatedAt: Date;
 }) {
   const attachments = Array.isArray(workOrder.attachments)
-    ? (workOrder.attachments as Prisma.JsonArray)
+    ? workOrder.attachments
+        .map((raw) => {
+          try {
+            return JSON.parse(raw) as Prisma.JsonValue;
+          } catch {
+            return null;
+          }
+        })
+        .filter((value): value is Prisma.JsonValue => value !== null)
     : [];
 
   return {
@@ -114,7 +122,7 @@ export async function createWorkOrder(req: TenantScopedRequest, res: Response) {
         assigneeId: data.assigneeId ?? null,
         dueDate: data.dueDate ? new Date(data.dueDate) : null,
         category: data.category ?? null,
-        attachments: (data.attachments ?? []) as Prisma.JsonValue,
+        attachments: (data.attachments ?? []).map((attachment) => JSON.stringify(attachment)),
       },
     });
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -19,6 +19,7 @@ import dashboardRoutes from './routes/dashboard';
 import assetRoutes from './routes/assets';
 import partRoutes from './routes/parts';
 import vendorRoutes from './routes/vendors';
+import purchaseOrderRoutes from './routes/purchaseOrders';
 import searchRoutes from './routes/search';
 
 
@@ -77,6 +78,8 @@ app.use('/api/auth', authRoutes);
 app.use('/api/work-orders', workOrderRoutes);
 app.use('/api/assets', assetRoutes);
 app.use('/api/dashboard', dashboardRoutes);
+app.use('/api/parts', partRoutes);
+app.use('/api/purchase-orders', purchaseOrderRoutes);
 
 // Error handling
 app.use(errorHandler);

--- a/backend/src/routes/dashboard.ts
+++ b/backend/src/routes/dashboard.ts
@@ -43,7 +43,12 @@ const querySchema = z
 
 type DashboardFilters = z.infer<typeof querySchema>;
 
-type TenantScopedFilters = DashboardFilters & { tenantId: string; userId: string };
+type TenantScopedFilters = Omit<DashboardFilters, 'from' | 'to'> & {
+  tenantId: string;
+  userId: string;
+};
+
+type TenantScopeWithRange = TenantScopedFilters & { from: Date; to: Date };
 
 type PriorityBuckets = Record<'critical' | 'high' | 'medium' | 'low', number>;
 
@@ -133,7 +138,7 @@ function normalizeNumber(value: number | null | undefined, precision = 1) {
   return Number(value.toFixed(precision));
 }
 
-async function loadOpenWorkOrders(scope: TenantScopedFilters & { to: Date }) {
+async function loadOpenWorkOrders(scope: TenantScopeWithRange) {
   const where = buildWorkOrderWhere(scope, { status: { in: OPEN_STATUSES } });
   const openOrders = await prisma.workOrder.findMany({
     where,
@@ -168,7 +173,7 @@ async function loadOpenWorkOrders(scope: TenantScopedFilters & { to: Date }) {
   };
 }
 
-async function loadMttr(scope: TenantScopedFilters & { from: Date; to: Date }) {
+async function loadMttr(scope: TenantScopeWithRange) {
   const where = buildWorkOrderWhere(scope, {
     status: 'completed',
     completedAt: {
@@ -234,7 +239,7 @@ async function loadMttr(scope: TenantScopedFilters & { from: Date; to: Date }) {
   };
 }
 
-async function loadUptime(scope: TenantScopedFilters & { from: Date; to: Date }) {
+async function loadUptime(scope: TenantScopeWithRange) {
   const assetWhere = buildAssetWhere(scope);
   const assetCount = await prisma.asset.count({ where: assetWhere });
 
@@ -291,24 +296,23 @@ async function loadStockout(scope: TenantScopedFilters) {
   const parts = await prisma.part.findMany({
     where: {
       tenantId: scope.tenantId,
-      ...(scope.siteId ? { siteId: scope.siteId } : {}),
     },
-    select: {
-      id: true,
-      name: true,
-      onHand: true,
-      minLevel: true,
+    include: {
+      stockLevels: true,
     },
   });
 
   const items = parts
-    .filter((part) => (part.onHand ?? 0) <= (part.minLevel ?? 0))
-    .map((part) => ({
-      partId: part.id,
-      name: part.name,
-      onHand: part.onHand ?? 0,
-      min: part.minLevel ?? 0,
-    }));
+    .map((part) => {
+      const onHand = part.stockLevels.reduce((sum, level) => sum + level.onHand, 0);
+      return {
+        partId: part.id,
+        name: part.name,
+        onHand,
+        min: part.defaultMinLevel,
+      };
+    })
+    .filter((part) => part.onHand <= part.min);
 
   return {
     count: items.length,
@@ -316,7 +320,7 @@ async function loadStockout(scope: TenantScopedFilters) {
   };
 }
 
-async function loadWorkOrdersByStatus(scope: TenantScopedFilters & { from: Date; to: Date }) {
+async function loadWorkOrdersByStatus(scope: TenantScopeWithRange) {
   const technicianScoped = scope.rolePreset === 'technician';
   const where = buildWorkOrderWhere(scope, {
     ...(technicianScoped ? { assigneeId: scope.userId } : {}),
@@ -353,7 +357,7 @@ async function loadWorkOrdersByStatus(scope: TenantScopedFilters & { from: Date;
   }));
 }
 
-async function loadTopDowntime(scope: TenantScopedFilters & { from: Date; to: Date }) {
+async function loadTopDowntime(scope: TenantScopeWithRange) {
   const logs = await prisma.downtimeLog.findMany({
     where: {
       tenantId: scope.tenantId,
@@ -485,7 +489,7 @@ export async function getDashboardMetrics(req: AuthRequest, res: Response) {
 
   const rolePreset = filters.rolePreset ?? (req.user.role?.toLowerCase?.() as DashboardFilters['rolePreset']);
 
-  const scope: TenantScopedFilters & { from: Date; to: Date } = {
+  const scope: TenantScopeWithRange = {
     ...filters,
     rolePreset,
     tenantId: req.user.tenantId,

--- a/backend/src/routes/parts.ts
+++ b/backend/src/routes/parts.ts
@@ -1,13 +1,404 @@
 import { Router } from 'express';
-import { authenticateToken } from '../middleware/auth';
-import { ok } from '../utils/response';
+import { z } from 'zod';
+import { Prisma } from '@prisma/client';
+import { authenticateToken, AuthRequest } from '../middleware/auth';
+import { prisma } from '../db';
+import { asyncHandler, fail, ok } from '../utils/response';
+import { ensureDefaultWarehouse } from '../services/warehouse';
 
 const router = Router();
 
+const OBJECT_ID_REGEX = /^[a-f\d]{24}$/iu;
+
+const emptyToUndefined = (value: unknown) => {
+  if (value === '' || value === null) {
+    return undefined;
+  }
+  return value;
+};
+
+const objectIdSchema = z
+  .string()
+  .trim()
+  .regex(OBJECT_ID_REGEX, 'Value must be a valid Mongo object id');
+
+const optionalInt = z
+  .preprocess(emptyToUndefined, z.coerce.number().int().min(0))
+  .optional();
+
+const optionalNumber = z
+  .preprocess(emptyToUndefined, z.coerce.number().min(0))
+  .optional();
+
+const partPayloadSchema = z.object({
+  sku: z.string().trim().min(1, 'SKU is required'),
+  name: z.string().trim().min(1, 'Part name is required'),
+  description: z.preprocess(emptyToUndefined, z.string().trim().min(1).optional()),
+  unitOfMeasure: z.preprocess(emptyToUndefined, z.string().trim().min(1).optional()),
+  min: optionalInt,
+  max: optionalInt,
+  cost: optionalNumber,
+  vendorId: objectIdSchema.optional(),
+});
+
+const createPartSchema = partPayloadSchema
+  .extend({
+    onHand: optionalInt,
+    warehouseId: objectIdSchema.optional(),
+  })
+  .refine(
+    (value) =>
+      value.max == null ||
+      value.min == null ||
+      Number.isNaN(value.max) ||
+      Number.isNaN(value.min) ||
+      value.max >= value.min,
+    {
+      message: 'Max level must be greater than or equal to min level',
+      path: ['max'],
+    },
+  );
+
+const updatePartSchema = partPayloadSchema
+  .extend({ warehouseId: objectIdSchema.optional() })
+  .partial()
+  .refine(
+    (value) =>
+      value.max == null ||
+      value.min == null ||
+      Number.isNaN(value.max) ||
+      Number.isNaN(value.min) ||
+      value.max >= value.min,
+    {
+      message: 'Max level must be greater than or equal to min level',
+      path: ['max'],
+    },
+  );
+
+const adjustSchema = z.object({
+  delta: z.preprocess(emptyToUndefined, z.coerce.number().int()).refine((val) => !Number.isNaN(val), {
+    message: 'Adjustment amount is required',
+  }),
+  reason: z.string().trim().min(1, 'Adjustment reason is required'),
+  warehouseId: objectIdSchema.optional(),
+  workOrderId: objectIdSchema.optional(),
+});
+
+const partInclude = {
+  preferredVendor: {
+    select: {
+      id: true,
+      name: true,
+    },
+  },
+  stockLevels: {
+    include: {
+      warehouse: {
+        select: {
+          id: true,
+          name: true,
+        },
+      },
+    },
+  },
+} satisfies Prisma.PartInclude;
+
+type PartWithRelations = Prisma.PartGetPayload<{ include: typeof partInclude }>;
+
+type StockLevelWithWarehouse = PartWithRelations['stockLevels'][number];
+
+function sumOnHand(levels: StockLevelWithWarehouse[]): number {
+  return levels.reduce((sum, level) => sum + level.onHand, 0);
+}
+
+function sumOnOrder(levels: StockLevelWithWarehouse[]): number {
+  return levels.reduce((sum, level) => sum + level.onOrder, 0);
+}
+
+function serializePart(part: PartWithRelations) {
+  const totalOnHand = sumOnHand(part.stockLevels);
+  return {
+    id: part.id,
+    tenantId: part.tenantId,
+    sku: part.sku,
+    name: part.name,
+    description: part.description ?? null,
+    min: part.defaultMinLevel,
+    max: part.defaultMaxLevel,
+    onHand: totalOnHand,
+    onOrder: sumOnOrder(part.stockLevels),
+    cost: part.cost ?? null,
+    vendorId: part.preferredVendorId ?? undefined,
+    createdAt: part.createdAt.toISOString(),
+    updatedAt: part.updatedAt.toISOString(),
+    vendor: part.preferredVendor
+      ? {
+          id: part.preferredVendor.id,
+          name: part.preferredVendor.name,
+        }
+      : undefined,
+  };
+}
+
+function buildLowStockAlerts(part: PartWithRelations) {
+  return part.stockLevels
+    .filter((level) => {
+      const threshold = level.minLevel ?? part.defaultMinLevel ?? 0;
+      return threshold > 0 && level.onHand < threshold;
+    })
+    .map((level) => ({
+      partId: part.id,
+      sku: part.sku,
+      name: part.name,
+      warehouseId: level.warehouseId,
+      warehouseName: level.warehouse?.name ?? 'Main Warehouse',
+      onHand: level.onHand,
+      minLevel: level.minLevel ?? part.defaultMinLevel ?? 0,
+    }));
+}
+
+async function findPartById(id: string, tenantId: string) {
+  return prisma.part.findFirst({
+    where: { id, tenantId },
+    include: partInclude,
+  });
+}
+
 router.use(authenticateToken);
 
-router.get('*', (_req, res) => {
-  return ok(res, []);
-});
+router.get(
+  '/',
+  asyncHandler(async (req: AuthRequest, res) => {
+    const tenantId = req.user!.tenantId;
+
+    const parts = await prisma.part.findMany({
+      where: { tenantId },
+      include: partInclude,
+      orderBy: { name: 'asc' },
+    });
+
+    const serialized = parts.map(serializePart);
+    const lowStockAlerts = parts.flatMap(buildLowStockAlerts);
+    const inventoryValue = parts.reduce((sum, part) => sum + sumOnHand(part.stockLevels) * (part.cost ?? 0), 0);
+    const backordered = parts.filter((part) => part.stockLevels.some((level) => level.onOrder > 0)).length;
+
+    return ok(res, {
+      parts: serialized,
+      stats: {
+        totalSkus: parts.length,
+        lowStock: lowStockAlerts.length,
+        backordered,
+        inventoryValue,
+      },
+      lowStock: lowStockAlerts,
+    });
+  }),
+);
+
+router.post(
+  '/',
+  asyncHandler(async (req: AuthRequest, res) => {
+    const tenantId = req.user!.tenantId;
+    const payload = createPartSchema.parse(req.body);
+
+    if (payload.vendorId) {
+      const vendor = await prisma.vendor.findFirst({ where: { id: payload.vendorId, tenantId } });
+      if (!vendor) {
+        return fail(res, 404, 'Vendor not found');
+      }
+    }
+
+    let warehouseId: string | null = payload.warehouseId ?? null;
+
+    if (warehouseId) {
+      const warehouse = await prisma.warehouse.findFirst({ where: { id: warehouseId, tenantId } });
+      if (!warehouse) {
+        return fail(res, 404, 'Warehouse not found');
+      }
+    } else {
+      const defaultWarehouse = await ensureDefaultWarehouse(tenantId);
+      warehouseId = defaultWarehouse.id;
+    }
+
+    const resolvedWarehouseId = warehouseId as string;
+
+    try {
+      const part = await prisma.part.create({
+        data: {
+          tenantId,
+          sku: payload.sku,
+          name: payload.name,
+          description: payload.description,
+          unitOfMeasure: payload.unitOfMeasure,
+          cost: payload.cost,
+          defaultMinLevel: payload.min ?? 0,
+          defaultMaxLevel: payload.max ?? 0,
+          preferredVendorId: payload.vendorId,
+          stockLevels: {
+            create: {
+              tenantId,
+              warehouseId: resolvedWarehouseId,
+              minLevel: payload.min ?? 0,
+              maxLevel: payload.max ?? 0,
+              onHand: payload.onHand ?? 0,
+            },
+          },
+        },
+        include: partInclude,
+      });
+
+      return ok(res.status(201), serializePart(part));
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+        return fail(res, 409, 'A part with this SKU already exists');
+      }
+      throw error;
+    }
+  }),
+);
+
+router.put(
+  '/:id',
+  asyncHandler(async (req: AuthRequest, res) => {
+    const tenantId = req.user!.tenantId;
+    const payload = updatePartSchema.parse(req.body);
+    const { id } = req.params;
+
+    const existing = await findPartById(id, tenantId);
+    if (!existing) {
+      return fail(res, 404, 'Part not found');
+    }
+
+    if (payload.vendorId) {
+      const vendor = await prisma.vendor.findFirst({ where: { id: payload.vendorId, tenantId } });
+      if (!vendor) {
+        return fail(res, 404, 'Vendor not found');
+      }
+    }
+
+    try {
+      const updated = await prisma.$transaction(async (tx) => {
+        await tx.part.update({
+          where: { id: existing.id },
+          data: {
+            sku: payload.sku ?? undefined,
+            name: payload.name ?? undefined,
+            description: payload.description ?? undefined,
+            unitOfMeasure: payload.unitOfMeasure ?? undefined,
+            cost: payload.cost ?? undefined,
+            defaultMinLevel: payload.min ?? existing.defaultMinLevel,
+            defaultMaxLevel: payload.max ?? existing.defaultMaxLevel,
+            preferredVendorId: payload.vendorId ?? existing.preferredVendorId ?? undefined,
+          },
+        });
+
+        if (payload.min != null || payload.max != null) {
+          await tx.stockLevel.updateMany({
+            where: { partId: existing.id },
+            data: {
+              ...(payload.min != null ? { minLevel: payload.min } : {}),
+              ...(payload.max != null ? { maxLevel: payload.max } : {}),
+            },
+          });
+        }
+
+        return tx.part.findUniqueOrThrow({ where: { id: existing.id }, include: partInclude });
+      });
+
+      return ok(res, serializePart(updated));
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+        return fail(res, 409, 'A part with this SKU already exists');
+      }
+      throw error;
+    }
+  }),
+);
+
+router.delete(
+  '/:id',
+  asyncHandler(async (req: AuthRequest, res) => {
+    const tenantId = req.user!.tenantId;
+    const { id } = req.params;
+
+    const existing = await findPartById(id, tenantId);
+    if (!existing) {
+      return fail(res, 404, 'Part not found');
+    }
+
+    await prisma.part.delete({ where: { id: existing.id } });
+
+    return ok(res, { success: true });
+  }),
+);
+
+router.post(
+  '/:id/adjust',
+  asyncHandler(async (req: AuthRequest, res) => {
+    const tenantId = req.user!.tenantId;
+    const { id } = req.params;
+    const payload = adjustSchema.parse(req.body);
+
+    const part = await findPartById(id, tenantId);
+    if (!part) {
+      return fail(res, 404, 'Part not found');
+    }
+
+    let warehouseId: string | null = payload.warehouseId ?? null;
+
+    if (warehouseId) {
+      const warehouse = await prisma.warehouse.findFirst({ where: { id: warehouseId, tenantId } });
+      if (!warehouse) {
+        return fail(res, 404, 'Warehouse not found');
+      }
+    } else {
+      const defaultWarehouse = await ensureDefaultWarehouse(tenantId);
+      warehouseId = defaultWarehouse.id;
+    }
+
+    const resolvedWarehouseId = warehouseId as string;
+
+    const stockLevel = await prisma.stockLevel.findFirst({
+      where: {
+        tenantId,
+        partId: part.id,
+        warehouseId: resolvedWarehouseId,
+      },
+    });
+
+    const newQuantity = (stockLevel?.onHand ?? 0) + payload.delta;
+    if (newQuantity < 0) {
+      return fail(res, 400, 'Adjustment would result in negative stock');
+    }
+
+    await prisma.$transaction(async (tx) => {
+      if (stockLevel) {
+        await tx.stockLevel.update({
+          where: { id: stockLevel.id },
+          data: { onHand: newQuantity },
+        });
+      } else {
+        await tx.stockLevel.create({
+          data: {
+            tenantId,
+            partId: part.id,
+            warehouseId: resolvedWarehouseId,
+            onHand: newQuantity,
+            minLevel: part.defaultMinLevel,
+            maxLevel: part.defaultMaxLevel,
+          },
+        });
+      }
+
+      await tx.part.update({
+        where: { id: part.id },
+        data: { updatedAt: new Date() },
+      });
+    });
+
+    const updated = await findPartById(id, tenantId);
+    return ok(res, serializePart(updated!));
+  }),
+);
 
 export default router;

--- a/backend/src/routes/purchaseOrders.ts
+++ b/backend/src/routes/purchaseOrders.ts
@@ -1,0 +1,507 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { Prisma, PurchaseOrderStatus } from '@prisma/client';
+import { authenticateToken, AuthRequest } from '../middleware/auth';
+import { prisma } from '../db';
+import { asyncHandler, fail, ok } from '../utils/response';
+import { ensureDefaultWarehouse } from '../services/warehouse';
+
+const router = Router();
+
+const OBJECT_ID_REGEX = /^[a-f\d]{24}$/iu;
+
+const emptyToUndefined = (value: unknown) => {
+  if (value === '' || value === null) {
+    return undefined;
+  }
+  return value;
+};
+
+const objectIdSchema = z
+  .string()
+  .trim()
+  .regex(OBJECT_ID_REGEX, 'Value must be a valid Mongo object id');
+
+const optionalString = z.preprocess(emptyToUndefined, z.string().trim().min(1).optional());
+const optionalNumber = z.preprocess(emptyToUndefined, z.coerce.number().min(0)).optional();
+const quantitySchema = z.preprocess(emptyToUndefined, z.coerce.number().int().positive());
+
+const purchaseOrderLineSchema = z.object({
+  partId: objectIdSchema,
+  quantity: quantitySchema,
+  unitCost: optionalNumber,
+  warehouseId: objectIdSchema.optional(),
+});
+
+const createPurchaseOrderSchema = z.object({
+  vendorId: objectIdSchema,
+  status: z.nativeEnum(PurchaseOrderStatus).optional(),
+  number: optionalString,
+  notes: optionalString,
+  orderedAt: z.preprocess(emptyToUndefined, z.coerce.date().optional()),
+  lines: z.array(purchaseOrderLineSchema).min(1, 'At least one line is required'),
+});
+
+const updatePurchaseOrderSchema = createPurchaseOrderSchema.partial().extend({
+  status: z.nativeEnum(PurchaseOrderStatus).optional(),
+});
+
+const receiveSchema = z.object({
+  receivedAt: z.preprocess(emptyToUndefined, z.coerce.date().optional()),
+  lines: z
+    .array(
+      z.object({
+        partId: objectIdSchema,
+        quantity: quantitySchema,
+        warehouseId: objectIdSchema.optional(),
+      }),
+    )
+    .min(1, 'At least one line must be provided for receipt'),
+});
+
+const purchaseOrderInclude = {
+  vendor: {
+    select: {
+      id: true,
+      name: true,
+    },
+  },
+  lines: {
+    include: {
+      part: {
+        select: {
+          id: true,
+          name: true,
+          sku: true,
+        },
+      },
+      warehouse: {
+        select: {
+          id: true,
+          name: true,
+        },
+      },
+    },
+  },
+} satisfies Prisma.PurchaseOrderInclude;
+
+type PurchaseOrderWithRelations = Prisma.PurchaseOrderGetPayload<{ include: typeof purchaseOrderInclude }>;
+
+type TransactionClient = Prisma.TransactionClient;
+
+router.use(authenticateToken);
+
+function serializePurchaseOrder(order: PurchaseOrderWithRelations) {
+  const subtotal = order.lines.reduce((sum, line) => sum + (line.unitCost ?? 0) * line.quantity, 0);
+  const totalReceived = order.lines.reduce((sum, line) => sum + line.receivedQty, 0);
+  const totalOrdered = order.lines.reduce((sum, line) => sum + line.quantity, 0);
+
+  return {
+    id: order.id,
+    tenantId: order.tenantId,
+    vendorId: order.vendorId,
+    status: order.status,
+    poNumber: order.number ?? order.id,
+    number: order.number,
+    notes: order.notes ?? null,
+    orderedAt: order.orderedAt ? order.orderedAt.toISOString() : null,
+    receivedAt: order.receivedAt ? order.receivedAt.toISOString() : null,
+    createdAt: order.createdAt.toISOString(),
+    updatedAt: order.updatedAt.toISOString(),
+    subtotal,
+    tax: 0,
+    shipping: 0,
+    total: subtotal,
+    receiptProgress: totalOrdered === 0 ? 0 : totalReceived / totalOrdered,
+    vendor: order.vendor
+      ? {
+          id: order.vendor.id,
+          name: order.vendor.name,
+        }
+      : null,
+    lines: order.lines.map((line) => ({
+      id: line.id,
+      partId: line.partId,
+      qty: line.quantity,
+      receivedQty: line.receivedQty,
+      unitCost: line.unitCost ?? 0,
+      warehouseId: line.warehouseId ?? null,
+    })),
+    linesWithDetails: order.lines.map((line) => ({
+      partName: line.part?.name ?? 'Unknown part',
+      partSku: line.part?.sku ?? '',
+      quantity: line.quantity,
+      unitCost: line.unitCost ?? 0,
+      receivedQty: line.receivedQty,
+      warehouseName: line.warehouse?.name ?? null,
+    })),
+  };
+}
+
+async function ensureVendorExists(tenantId: string, vendorId: string) {
+  const vendor = await prisma.vendor.findFirst({ where: { tenantId, id: vendorId } });
+  if (!vendor) {
+    throw new Error('Vendor not found');
+  }
+}
+
+async function ensurePartsExist(tenantId: string, partIds: string[]) {
+  const uniqueIds = Array.from(new Set(partIds));
+  if (uniqueIds.length === 0) {
+    return;
+  }
+
+  const parts = await prisma.part.findMany({ where: { tenantId, id: { in: uniqueIds } } });
+  if (parts.length !== uniqueIds.length) {
+    throw new Error('One or more parts were not found for this tenant');
+  }
+}
+
+async function ensureWarehousesExist(tenantId: string, warehouseIds: string[]) {
+  const uniqueIds = Array.from(new Set(warehouseIds.filter(Boolean)));
+  if (uniqueIds.length === 0) {
+    return;
+  }
+
+  const warehouses = await prisma.warehouse.findMany({ where: { tenantId, id: { in: uniqueIds } } });
+  if (warehouses.length !== uniqueIds.length) {
+    throw new Error('One or more warehouses were not found for this tenant');
+  }
+}
+
+async function recalcOnOrder(tx: TransactionClient, tenantId: string, partId: string) {
+  const openLines = await tx.purchaseOrderLine.findMany({
+    where: {
+      tenantId,
+      partId,
+      purchaseOrder: {
+        tenantId,
+        status: { in: [PurchaseOrderStatus.issued] },
+      },
+    },
+    select: {
+      quantity: true,
+      receivedQty: true,
+    },
+  });
+
+  const onOrder = openLines.reduce((sum, line) => sum + Math.max(line.quantity - line.receivedQty, 0), 0);
+
+  const updateResult = await tx.stockLevel.updateMany({
+    where: { tenantId, partId },
+    data: { onOrder },
+  });
+
+  if (updateResult.count === 0 && (onOrder > 0 || openLines.length > 0)) {
+    const defaultWarehouse = await ensureDefaultWarehouse(tenantId, tx);
+    const part = await tx.part.findUnique({ where: { id: partId } });
+
+    if (part) {
+      await tx.stockLevel.create({
+        data: {
+          tenantId,
+          partId,
+          warehouseId: defaultWarehouse.id,
+          onHand: 0,
+          onOrder,
+          minLevel: part.defaultMinLevel,
+          maxLevel: part.defaultMaxLevel,
+        },
+      });
+    }
+  }
+}
+
+router.get(
+  '/',
+  asyncHandler(async (req: AuthRequest, res) => {
+    const tenantId = req.user!.tenantId;
+    const status = typeof req.query.status === 'string' ? req.query.status : undefined;
+    const search = typeof req.query.q === 'string' ? req.query.q.trim() : undefined;
+
+    const where: Prisma.PurchaseOrderWhereInput = {
+      tenantId,
+    };
+
+    if (status && Object.values(PurchaseOrderStatus).includes(status as PurchaseOrderStatus)) {
+      where.status = status as PurchaseOrderStatus;
+    }
+
+    if (search) {
+      where.OR = [
+        { number: { contains: search, mode: 'insensitive' } },
+        { vendor: { name: { contains: search, mode: 'insensitive' } } },
+      ];
+    }
+
+    const orders = await prisma.purchaseOrder.findMany({
+      where,
+      include: purchaseOrderInclude,
+      orderBy: { createdAt: 'desc' },
+    });
+
+    return ok(res, orders.map(serializePurchaseOrder));
+  }),
+);
+
+router.post(
+  '/',
+  asyncHandler(async (req: AuthRequest, res) => {
+    const tenantId = req.user!.tenantId;
+    const payload = createPurchaseOrderSchema.parse(req.body);
+
+    try {
+      await ensureVendorExists(tenantId, payload.vendorId);
+      await ensurePartsExist(tenantId, payload.lines.map((line) => line.partId));
+      await ensureWarehousesExist(
+        tenantId,
+        payload.lines.map((line) => line.warehouseId).filter(Boolean) as string[],
+      );
+    } catch (error) {
+      return fail(res, 404, error instanceof Error ? error.message : 'Invalid references provided');
+    }
+
+    const order = await prisma.$transaction(async (tx) => {
+      const created = await tx.purchaseOrder.create({
+        data: {
+          tenantId,
+          vendorId: payload.vendorId,
+          status: payload.status ?? PurchaseOrderStatus.draft,
+          number: payload.number,
+          notes: payload.notes,
+          orderedAt: payload.orderedAt ?? (payload.status === PurchaseOrderStatus.issued ? new Date() : undefined),
+          lines: {
+            create: payload.lines.map((line) => ({
+              tenantId,
+              partId: line.partId,
+              warehouseId: line.warehouseId,
+              quantity: line.quantity,
+              unitCost: line.unitCost,
+            })),
+          },
+        },
+        include: purchaseOrderInclude,
+      });
+
+      const partIds = Array.from(new Set(payload.lines.map((line) => line.partId)));
+      await Promise.all(partIds.map((partId) => recalcOnOrder(tx, tenantId, partId)));
+
+      return created;
+    });
+
+    return ok(res.status(201), serializePurchaseOrder(order));
+  }),
+);
+
+router.put(
+  '/:id',
+  asyncHandler(async (req: AuthRequest, res) => {
+    const tenantId = req.user!.tenantId;
+    const { id } = req.params;
+    const payload = updatePurchaseOrderSchema.parse(req.body);
+
+    const existing = await prisma.purchaseOrder.findFirst({
+      where: { tenantId, id },
+      include: {
+        lines: true,
+      },
+    });
+
+    if (!existing) {
+      return fail(res, 404, 'Purchase order not found');
+    }
+
+    if (payload.vendorId) {
+      try {
+        await ensureVendorExists(tenantId, payload.vendorId);
+      } catch (error) {
+        return fail(res, 404, error instanceof Error ? error.message : 'Vendor not found');
+      }
+    }
+
+    if (payload.lines) {
+      try {
+        await ensurePartsExist(tenantId, payload.lines.map((line) => line.partId));
+        await ensureWarehousesExist(
+          tenantId,
+          payload.lines.map((line) => line.warehouseId).filter(Boolean) as string[],
+        );
+      } catch (error) {
+        return fail(res, 404, error instanceof Error ? error.message : 'Invalid line references');
+      }
+    }
+
+    const updated = await prisma.$transaction(async (tx) => {
+      const updatedOrder = await tx.purchaseOrder.update({
+        where: { id: existing.id },
+        data: {
+          vendorId: payload.vendorId ?? undefined,
+          status: payload.status ?? undefined,
+          number: payload.number ?? undefined,
+          notes: payload.notes ?? undefined,
+          orderedAt:
+            payload.orderedAt ??
+            (payload.status && payload.status === PurchaseOrderStatus.issued && !existing.orderedAt
+              ? new Date()
+              : undefined),
+        },
+      });
+
+      const touchedPartIds = new Set<string>();
+
+      if (payload.lines) {
+        await tx.purchaseOrderLine.deleteMany({ where: { purchaseOrderId: existing.id } });
+
+        for (const line of payload.lines) {
+          const matchingExisting = existing.lines.find((l) => l.partId === line.partId);
+          await tx.purchaseOrderLine.create({
+            data: {
+              tenantId,
+              purchaseOrderId: existing.id,
+              partId: line.partId,
+              warehouseId: line.warehouseId,
+              quantity: line.quantity,
+              unitCost: line.unitCost,
+              receivedQty: Math.min(matchingExisting?.receivedQty ?? 0, line.quantity),
+            },
+          });
+          touchedPartIds.add(line.partId);
+        }
+      } else {
+        for (const line of existing.lines) {
+          touchedPartIds.add(line.partId);
+        }
+      }
+
+      if (payload.status === PurchaseOrderStatus.closed || payload.status === PurchaseOrderStatus.received) {
+        await tx.purchaseOrder.update({
+          where: { id: existing.id },
+          data: {
+            receivedAt: payload.status === PurchaseOrderStatus.received ? new Date() : updatedOrder.receivedAt,
+          },
+        });
+      }
+
+      const reloaded = await tx.purchaseOrder.findUniqueOrThrow({
+        where: { id: existing.id },
+        include: purchaseOrderInclude,
+      });
+
+      await Promise.all(Array.from(touchedPartIds).map((partId) => recalcOnOrder(tx, tenantId, partId)));
+
+      return reloaded;
+    });
+
+    return ok(res, serializePurchaseOrder(updated));
+  }),
+);
+
+router.post(
+  '/:id/receive',
+  asyncHandler(async (req: AuthRequest, res) => {
+    const tenantId = req.user!.tenantId;
+    const { id } = req.params;
+    const payload = receiveSchema.parse(req.body);
+
+    const existing = await prisma.purchaseOrder.findFirst({
+      where: { tenantId, id },
+      include: {
+        lines: true,
+      },
+    });
+
+    if (!existing) {
+      return fail(res, 404, 'Purchase order not found');
+    }
+
+    const order = await prisma.$transaction(async (tx) => {
+      const partIds = new Set<string>();
+
+      for (const lineReceipt of payload.lines) {
+        const line = existing.lines.find((l) => l.partId === lineReceipt.partId);
+        if (!line) {
+          throw new Error(`Part ${lineReceipt.partId} is not on this purchase order`);
+        }
+
+        const remaining = Math.max(line.quantity - line.receivedQty, 0);
+        const toReceive = Math.min(lineReceipt.quantity, remaining);
+
+        if (toReceive <= 0) {
+          continue;
+        }
+
+        let warehouseId = lineReceipt.warehouseId ?? line.warehouseId ?? null;
+        if (!warehouseId) {
+          const defaultWarehouse = await ensureDefaultWarehouse(tenantId, tx);
+          warehouseId = defaultWarehouse.id;
+        }
+
+        const part = await tx.part.findUniqueOrThrow({ where: { id: line.partId } });
+        const stockLevel = await tx.stockLevel.findFirst({
+          where: {
+            tenantId,
+            partId: line.partId,
+            warehouseId,
+          },
+        });
+
+        if (stockLevel) {
+          await tx.stockLevel.update({
+            where: { id: stockLevel.id },
+            data: {
+              onHand: stockLevel.onHand + toReceive,
+            },
+          });
+        } else {
+          await tx.stockLevel.create({
+            data: {
+              tenantId,
+              partId: line.partId,
+              warehouseId,
+              onHand: toReceive,
+              minLevel: part.defaultMinLevel,
+              maxLevel: part.defaultMaxLevel,
+            },
+          });
+        }
+
+        await tx.purchaseOrderLine.update({
+          where: { id: line.id },
+          data: {
+            receivedQty: line.receivedQty + toReceive,
+            warehouseId,
+          },
+        });
+
+        partIds.add(line.partId);
+      }
+
+      const allLines = await tx.purchaseOrderLine.findMany({
+        where: { purchaseOrderId: existing.id },
+      });
+
+      const fullyReceived = allLines.every((line) => line.receivedQty >= line.quantity);
+
+      await tx.purchaseOrder.update({
+        where: { id: existing.id },
+        data: {
+          status: fullyReceived ? PurchaseOrderStatus.received : existing.status,
+          receivedAt: payload.receivedAt ? payload.receivedAt : fullyReceived ? new Date() : existing.receivedAt,
+        },
+      });
+
+      const refreshed = await tx.purchaseOrder.findUniqueOrThrow({
+        where: { id: existing.id },
+        include: purchaseOrderInclude,
+      });
+
+      await Promise.all(Array.from(partIds).map((partId) => recalcOnOrder(tx, tenantId, partId)));
+
+      return refreshed;
+    });
+
+    return ok(res, serializePurchaseOrder(order));
+  }),
+);
+
+export default router;

--- a/backend/src/scripts/seedDashboardDemo.ts
+++ b/backend/src/scripts/seedDashboardDemo.ts
@@ -1,12 +1,13 @@
 import crypto from 'crypto';
 import { addDays, subDays } from 'date-fns';
 import { prisma } from '../db';
+import { ensureDefaultWarehouse } from '../services/warehouse';
 
 function objectId(): string {
   return crypto.randomBytes(12).toString('hex');
 }
 
-function randomChoice<T>(values: T[]): T {
+function randomChoice<T>(values: readonly T[]): T {
   return values[Math.floor(Math.random() * values.length)]!;
 }
 
@@ -169,20 +170,28 @@ function buildDowntimeLogs(
   return logs;
 }
 
-function buildParts(tenantId: string, siteIds: string[]) {
-  const parts: any[] = [];
+type SeedPart = {
+  name: string;
+  sku: string;
+  onHand: number;
+  minLevel: number;
+  maxLevel: number;
+  cost: number;
+};
+
+function buildParts(): SeedPart[] {
+  const parts: SeedPart[] = [];
 
   for (let i = 0; i < 180; i += 1) {
     const minLevel = randomInt(1, 20);
-    const onHand = randomInt(0, 40);
+    const maxLevel = minLevel + randomInt(5, 25);
 
     parts.push({
-      tenantId,
-      siteId: randomChoice(siteIds),
       name: `Part ${(i + 1).toString().padStart(3, '0')}`,
       sku: `SKU-${(i + 1).toString().padStart(5, '0')}`,
       minLevel,
-      onHand,
+      maxLevel,
+      onHand: randomInt(0, 40),
       cost: Number((Math.random() * 500).toFixed(2)),
     });
   }
@@ -210,8 +219,30 @@ async function main() {
   }
 
   console.log('🌱 Seeding parts...');
-  const parts = buildParts(tenantId, siteIds);
-  await prisma.part.createMany({ data: parts, skipDuplicates: true });
+  const parts = buildParts();
+  const defaultWarehouse = await ensureDefaultWarehouse(tenantId);
+
+  for (const part of parts) {
+    await prisma.part.create({
+      data: {
+        tenantId,
+        name: part.name,
+        sku: part.sku,
+        cost: part.cost,
+        defaultMinLevel: part.minLevel,
+        defaultMaxLevel: part.maxLevel,
+        stockLevels: {
+          create: {
+            tenantId,
+            warehouseId: defaultWarehouse.id,
+            onHand: part.onHand,
+            minLevel: part.minLevel,
+            maxLevel: part.maxLevel,
+          },
+        },
+      },
+    });
+  }
 
   console.log('✅ Dashboard demo data ready');
 }

--- a/backend/src/services/warehouse.ts
+++ b/backend/src/services/warehouse.ts
@@ -1,0 +1,23 @@
+import type { PrismaClient, Prisma } from '@prisma/client';
+import { prisma } from '../db';
+
+type WarehouseClient = PrismaClient | Prisma.TransactionClient;
+
+export async function ensureDefaultWarehouse(tenantId: string, client: WarehouseClient = prisma) {
+  const existing = await client.warehouse.findFirst({
+    where: { tenantId, isDefault: true },
+  });
+
+  if (existing) {
+    return existing;
+  }
+
+  return client.warehouse.create({
+    data: {
+      tenantId,
+      name: 'Main Warehouse',
+      code: 'MAIN',
+      isDefault: true,
+    },
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@hookform/resolvers": "^3.9.0",
-        "@prisma/client": "^6.16.2",
+        "@prisma/client": "^6.16.3",
         "@tanstack/react-query": "^4.41.0",
         "lucide-react": "^0.544.0",
         "react": "^18.2.0",
@@ -30,7 +30,7 @@
         "concurrently": "^9.2.1",
         "eslint": "^8.57.0",
         "postcss": "^8.4.38",
-        "prisma": "^6.16.2",
+        "prisma": "^6.16.3",
         "tailwindcss": "^3.4.3",
         "typescript": "^5.2.2",
         "vite": "^5.2.0",
@@ -961,9 +961,9 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "6.16.2",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.16.2.tgz",
-      "integrity": "sha512-E00PxBcalMfYO/TWnXobBVUai6eW/g5OsifWQsQDzJYm7yaY+IRLo7ZLsaefi0QkTpxfuhFcQ/w180i6kX3iJw==",
+      "version": "6.16.3",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.16.3.tgz",
+      "integrity": "sha512-JfNfAtXG+/lIopsvoZlZiH2k5yNx87mcTS4t9/S5oufM1nKdXYxOvpDC1XoTCFBa5cQh7uXnbMPsmZrwZY80xw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "engines": {
@@ -983,9 +983,9 @@
       }
     },
     "node_modules/@prisma/config": {
-      "version": "6.16.2",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.16.2.tgz",
-      "integrity": "sha512-mKXSUrcqXj0LXWPmJsK2s3p9PN+aoAbyMx7m5E1v1FufofR1ZpPoIArjjzOIm+bJRLLvYftoNYLx1tbHgF9/yg==",
+      "version": "6.16.3",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.16.3.tgz",
+      "integrity": "sha512-VlsLnG4oOuKGGMToEeVaRhoTBZu5H3q51jTQXb/diRags3WV0+BQK5MolJTtP6G7COlzoXmWeS11rNBtvg+qFQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -996,53 +996,53 @@
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "6.16.2",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.16.2.tgz",
-      "integrity": "sha512-bo4/gA/HVV6u8YK2uY6glhNsJ7r+k/i5iQ9ny/3q5bt9ijCj7WMPUwfTKPvtEgLP+/r26Z686ly11hhcLiQ8zA==",
+      "version": "6.16.3",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.16.3.tgz",
+      "integrity": "sha512-89DdqWtdKd7qoc9/qJCKLTazj3W3zPEiz0hc7HfZdpjzm21c7orOUB5oHWJsG+4KbV4cWU5pefq3CuDVYF9vgA==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
-      "version": "6.16.2",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.16.2.tgz",
-      "integrity": "sha512-7yf3AjfPUgsg/l7JSu1iEhsmZZ/YE00yURPjTikqm2z4btM0bCl2coFtTGfeSOWbQMmq45Jab+53yGUIAT1sjA==",
+      "version": "6.16.3",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.16.3.tgz",
+      "integrity": "sha512-b+Rl4nzQDcoqe6RIpSHv8f5lLnwdDGvXhHjGDiokObguAAv/O1KaX1Oc69mBW/GFWKQpCkOraobLjU6s1h8HGg==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.16.2",
-        "@prisma/engines-version": "6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43",
-        "@prisma/fetch-engine": "6.16.2",
-        "@prisma/get-platform": "6.16.2"
+        "@prisma/debug": "6.16.3",
+        "@prisma/engines-version": "6.16.1-1.bb420e667c1820a8c05a38023385f6cc7ef8e83a",
+        "@prisma/fetch-engine": "6.16.3",
+        "@prisma/get-platform": "6.16.3"
       }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43.tgz",
-      "integrity": "sha512-ThvlDaKIVrnrv97ujNFDYiQbeMQpLa0O86HFA2mNoip4mtFqM7U5GSz2ie1i2xByZtvPztJlNRgPsXGeM/kqAA==",
+      "version": "6.16.1-1.bb420e667c1820a8c05a38023385f6cc7ef8e83a",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.16.1-1.bb420e667c1820a8c05a38023385f6cc7ef8e83a.tgz",
+      "integrity": "sha512-fftRmosBex48Ph1v2ll1FrPpirwtPZpNkE5CDCY1Lw2SD2ctyrLlVlHiuxDAAlALwWBOkPbAll4+EaqdGuMhJw==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "6.16.2",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.16.2.tgz",
-      "integrity": "sha512-wPnZ8DMRqpgzye758ZvfAMiNJRuYpz+rhgEBZi60ZqDIgOU2694oJxiuu3GKFeYeR/hXxso4/2oBC243t/whxQ==",
+      "version": "6.16.3",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.16.3.tgz",
+      "integrity": "sha512-bUoRIkVaI+CCaVGrSfcKev0/Mk4ateubqWqGZvQ9uCqFv2ENwWIR3OeNuGin96nZn5+SkebcD7RGgKr/+mJelw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.16.2",
-        "@prisma/engines-version": "6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43",
-        "@prisma/get-platform": "6.16.2"
+        "@prisma/debug": "6.16.3",
+        "@prisma/engines-version": "6.16.1-1.bb420e667c1820a8c05a38023385f6cc7ef8e83a",
+        "@prisma/get-platform": "6.16.3"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "6.16.2",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.16.2.tgz",
-      "integrity": "sha512-U/P36Uke5wS7r1+omtAgJpEB94tlT4SdlgaeTc6HVTTT93pXj7zZ+B/cZnmnvjcNPfWddgoDx8RLjmQwqGDYyA==",
+      "version": "6.16.3",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.16.3.tgz",
+      "integrity": "sha512-X1LxiFXinJ4iQehrodGp0f66Dv6cDL0GbRlcCoLtSu6f4Wi+hgo7eND/afIs5029GQLgNWKZ46vn8hjyXTsHLA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.16.2"
+        "@prisma/debug": "6.16.3"
       }
     },
     "node_modules/@remix-run/router": {
@@ -2339,9 +2339,9 @@
       "license": "MIT"
     },
     "node_modules/c12/node_modules/jiti": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.0.tgz",
-      "integrity": "sha512-VXe6RjJkBPj0ohtqaO8vSWP3ZhAKo66fKrFNCll4BTcwljPLz03pCbaNKfzGP5MbrCYcbJ7v0nOYYwUzTEIdXQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "devOptional": true,
       "license": "MIT",
       "bin": {
@@ -4681,15 +4681,15 @@
       }
     },
     "node_modules/prisma": {
-      "version": "6.16.2",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.16.2.tgz",
-      "integrity": "sha512-aRvldGE5UUJTtVmFiH3WfNFNiqFlAtePUxcI0UEGlnXCX7DqhiMT5TRYwncHFeA/Reca5W6ToXXyCMTeFPdSXA==",
+      "version": "6.16.3",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.16.3.tgz",
+      "integrity": "sha512-4tJq3KB9WRshH5+QmzOLV54YMkNlKOtLKaSdvraI5kC/axF47HuOw6zDM8xrxJ6s9o2WodY654On4XKkrobQdQ==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/config": "6.16.2",
-        "@prisma/engines": "6.16.2"
+        "@prisma/config": "6.16.3",
+        "@prisma/engines": "6.16.3"
       },
       "bin": {
         "prisma": "build/index.js"

--- a/shared/types/inventory.ts
+++ b/shared/types/inventory.ts
@@ -3,17 +3,43 @@ export interface Part {
   tenantId: string;
   sku: string;
   name: string;
+  description?: string | null;
   min: number;
   max: number;
   onHand: number;
-  cost: number;
+  onOrder: number;
+  cost: number | null;
   vendorId?: string;
+  unitOfMeasure?: string | null;
   createdAt: string;
   updatedAt: string;
   vendor?: {
     id: string;
     name: string;
   };
+}
+
+export interface InventoryStats {
+  totalSkus: number;
+  lowStock: number;
+  backordered: number;
+  inventoryValue: number;
+}
+
+export interface LowStockAlert {
+  partId: string;
+  sku: string;
+  name: string;
+  warehouseId: string | null;
+  warehouseName: string | null;
+  onHand: number;
+  minLevel: number;
+}
+
+export interface PartsResponse {
+  parts: Part[];
+  stats: InventoryStats;
+  lowStock: LowStockAlert[];
 }
 
 export interface Vendor {
@@ -47,6 +73,8 @@ export interface PurchaseOrderLine {
   partId: string;
   qty: number;
   unitCost: number;
+  receivedQty?: number;
+  warehouseId?: string | null;
 }
 
 export interface CreatePartRequest {
@@ -57,6 +85,8 @@ export interface CreatePartRequest {
   onHand?: number;
   cost?: number;
   vendorId?: string;
+  description?: string;
+  unitOfMeasure?: string;
 }
 
 export interface UpdatePartRequest {
@@ -66,6 +96,8 @@ export interface UpdatePartRequest {
   max?: number;
   cost?: number;
   vendorId?: string;
+  description?: string;
+  unitOfMeasure?: string;
 }
 
 export interface AdjustPartRequest {

--- a/src/pages/Inventory.tsx
+++ b/src/pages/Inventory.tsx
@@ -1,32 +1,213 @@
+import { FormEvent, useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { AlertTriangle, Package, PackageSearch, Plus, TrendingDown } from 'lucide-react';
+import { api } from '../lib/api';
+import { Button } from '../components/ui/button';
+import { Input } from '../components/ui/input';
+import { SlideOver } from '../components/premium/SlideOver';
+import type {
+  CreatePartRequest,
+  Part,
+  PartsResponse,
+  UpdatePartRequest,
+} from '../../shared/types/inventory';
 
-const stats = [
-  { label: 'Total SKUs', value: '1,250', icon: Package },
-  { label: 'Low stock', value: '23', icon: AlertTriangle },
-  { label: 'Backordered', value: '8', icon: TrendingDown },
-  { label: 'Inventory value', value: '$125K', icon: PackageSearch }
-];
+interface FormState {
+  sku: string;
+  name: string;
+  description: string;
+  unitOfMeasure: string;
+  min: string;
+  max: string;
+  onHand: string;
+  cost: string;
+  vendorId: string;
+}
 
-const lowStock = [
-  { sku: 'PUMP-SEAL-001', description: 'Pump seal kit', site: 'Plant 1', onHand: 3 },
-  { sku: 'BELT-V-002', description: 'V-belt 4L360', site: 'Plant 2', onHand: 2 },
-  { sku: 'FILTER-12', description: 'HEPA Filter', site: 'Corporate HQ', onHand: 1 }
-];
+type DrawerMode = 'create' | 'edit';
+
+type UpdatePayload = { id: string; data: UpdatePartRequest };
+
+type PartsQueryResult = PartsResponse;
+
+const numberFormatter = new Intl.NumberFormat();
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+function toFormState(part?: Part): FormState {
+  return {
+    sku: part?.sku ?? '',
+    name: part?.name ?? '',
+    description: part?.description ?? '',
+    unitOfMeasure: part?.unitOfMeasure ?? '',
+    min: part ? String(part.min ?? 0) : '',
+    max: part ? String(part.max ?? 0) : '',
+    onHand: part ? String(part.onHand ?? 0) : '',
+    cost: part?.cost != null ? String(part.cost) : '',
+    vendorId: part?.vendorId ?? '',
+  };
+}
+
+function parseInteger(value: string): number | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  const parsed = Number.parseInt(trimmed, 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function parseNumber(value: string): number | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  const parsed = Number.parseFloat(trimmed);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
 
 export default function Inventory() {
+  const queryClient = useQueryClient();
+  const [drawerMode, setDrawerMode] = useState<DrawerMode>('create');
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [activePart, setActivePart] = useState<Part | null>(null);
+  const [formState, setFormState] = useState<FormState>(() => toFormState());
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const { data, isLoading, isError, error } = useQuery<PartsQueryResult>({
+    queryKey: ['parts'],
+    queryFn: () => api.get<PartsQueryResult>('/parts'),
+  });
+
+  const createPart = useMutation({
+    mutationFn: (payload: CreatePartRequest) => api.post<Part>('/parts', payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['parts'] });
+    },
+  });
+
+  const updatePart = useMutation({
+    mutationFn: (payload: UpdatePayload) => api.put<Part>(`/parts/${payload.id}`, payload.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['parts'] });
+    },
+  });
+
+  const statsCards = useMemo(() => {
+    const stats = data?.stats;
+    return [
+      { label: 'Total SKUs', value: stats ? numberFormatter.format(stats.totalSkus) : '–', icon: Package },
+      { label: 'Low stock', value: stats ? numberFormatter.format(stats.lowStock) : '–', icon: AlertTriangle },
+      { label: 'Backordered', value: stats ? numberFormatter.format(stats.backordered) : '–', icon: TrendingDown },
+      {
+        label: 'Inventory value',
+        value: stats ? formatCurrency(stats.inventoryValue) : '–',
+        icon: PackageSearch,
+      },
+    ];
+  }, [data?.stats]);
+
+  const parts = data?.parts ?? [];
+  const lowStock = data?.lowStock ?? [];
+
+  const saving = createPart.isPending || updatePart.isPending;
+
+  const openDrawer = (mode: DrawerMode, part: Part | null = null) => {
+    setDrawerMode(mode);
+    setActivePart(part);
+    setFormState(toFormState(part ?? undefined));
+    setFormError(null);
+    setDrawerOpen(true);
+  };
+
+  const closeDrawer = () => {
+    setDrawerOpen(false);
+    setFormError(null);
+  };
+
+  const handleFormChange = (field: keyof FormState, value: string) => {
+    setFormState((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setFormError(null);
+
+    const payloadBase: UpdatePartRequest & Partial<CreatePartRequest> = {
+      sku: formState.sku.trim(),
+      name: formState.name.trim(),
+      description: formState.description.trim() || undefined,
+      unitOfMeasure: formState.unitOfMeasure.trim() || undefined,
+      min: parseInteger(formState.min),
+      max: parseInteger(formState.max),
+      cost: parseNumber(formState.cost),
+      vendorId: formState.vendorId.trim() || undefined,
+    };
+
+    if (!payloadBase.sku || !payloadBase.name) {
+      setFormError('SKU and name are required fields.');
+      return;
+    }
+
+    try {
+      if (drawerMode === 'create') {
+        const createPayload: CreatePartRequest = {
+          ...payloadBase,
+          sku: payloadBase.sku,
+          name: payloadBase.name,
+          min: payloadBase.min,
+          max: payloadBase.max,
+          cost: payloadBase.cost,
+          vendorId: payloadBase.vendorId,
+          description: payloadBase.description,
+          unitOfMeasure: payloadBase.unitOfMeasure,
+          onHand: parseInteger(formState.onHand) ?? 0,
+        };
+
+        await createPart.mutateAsync(createPayload);
+      } else if (activePart) {
+        const updatePayload: UpdatePayload = {
+          id: activePart.id,
+          data: {
+            ...payloadBase,
+            sku: payloadBase.sku,
+            name: payloadBase.name,
+          },
+        };
+
+        await updatePart.mutateAsync(updatePayload);
+      }
+
+      closeDrawer();
+    } catch (mutationError) {
+      setFormError(mutationError instanceof Error ? mutationError.message : 'Failed to save part');
+    }
+  };
+
   return (
     <div className="space-y-8">
       <header className="flex flex-wrap items-end justify-between gap-4">
         <div>
           <h1 className="text-3xl font-semibold text-fg">Inventory</h1>
-          <p className="mt-2 text-sm text-mutedfg">Monitor critical spares, reorder signals, and part availability across sites.</p>
+          <p className="mt-2 text-sm text-mutedfg">
+            Monitor critical spares, reorder signals, and part availability across sites.
+          </p>
         </div>
-        <button className="inline-flex items-center gap-2 rounded-2xl bg-brand px-4 py-2 text-sm font-semibold text-white shadow-lg">
+        <Button onClick={() => openDrawer('create')} className="gap-2 rounded-2xl px-4 py-2 text-sm font-semibold shadow-lg">
           <Plus className="h-4 w-4" /> New part
-        </button>
+        </Button>
       </header>
+
+      {isError && (
+        <div className="rounded-3xl border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
+          {error instanceof Error ? error.message : 'Failed to load inventory data'}
+        </div>
+      )}
+
       <section className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
-        {stats.map((stat) => {
+        {statsCards.map((stat) => {
           const Icon = stat.icon;
           return (
             <article key={stat.label} className="rounded-3xl border border-border bg-surface p-6 shadow-xl">
@@ -43,33 +224,247 @@ export default function Inventory() {
           );
         })}
       </section>
+
       <section className="rounded-3xl border border-border bg-surface p-6 shadow-xl">
         <div className="flex items-center justify-between">
           <div>
             <h2 className="text-lg font-semibold text-fg">Low stock alerts</h2>
             <p className="text-sm text-mutedfg">Parts that have fallen below par levels.</p>
           </div>
-          <button className="rounded-2xl border border-border px-3 py-1 text-xs font-semibold text-fg">Export CSV</button>
         </div>
         <div className="mt-6 space-y-3">
-          {lowStock.map((item) => (
-            <div key={item.sku} className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-border px-4 py-3 text-sm text-mutedfg">
-              <div>
-                <p className="font-semibold text-fg">{item.sku}</p>
-                <p>{item.description}</p>
-              </div>
-              <div className="flex items-center gap-4">
-                <span className="rounded-full bg-muted px-3 py-1 text-xs text-mutedfg">{item.site}</span>
-                <span className="rounded-full bg-danger/10 px-3 py-1 text-xs font-semibold text-danger">{item.onHand} on hand</span>
-              </div>
+          {lowStock.length === 0 && !isLoading && (
+            <div className="rounded-2xl border border-dashed border-border px-4 py-6 text-center text-sm text-mutedfg">
+              All parts are above their minimum thresholds.
             </div>
-          ))}
+          )}
+          {isLoading && (
+            <div className="space-y-3">
+              {Array.from({ length: 3 }).map((_, index) => (
+                <div key={index} className="h-16 animate-pulse rounded-2xl bg-muted" />
+              ))}
+            </div>
+          )}
+          {!isLoading &&
+            lowStock.map((item) => (
+              <div
+                key={`${item.partId}-${item.warehouseId ?? 'default'}`}
+                className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-border px-4 py-3 text-sm text-mutedfg"
+              >
+                <div>
+                  <p className="font-semibold text-fg">{item.sku}</p>
+                  <p>{parts.find((part) => part.id === item.partId)?.name ?? item.name}</p>
+                </div>
+                <div className="flex items-center gap-4">
+                  <span className="rounded-full bg-muted px-3 py-1 text-xs text-mutedfg">
+                    {item.warehouseName ?? 'Main warehouse'}
+                  </span>
+                  <span className="rounded-full bg-danger/10 px-3 py-1 text-xs font-semibold text-danger">
+                    {item.onHand} on hand (min {item.minLevel})
+                  </span>
+                </div>
+              </div>
+            ))}
         </div>
       </section>
+
+      <section className="rounded-3xl border border-border bg-surface p-6 shadow-xl">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-fg">Parts catalogue</h2>
+            <p className="text-sm text-mutedfg">Current SKUs with on-hand balances and thresholds.</p>
+          </div>
+        </div>
+        <div className="mt-6 overflow-hidden rounded-2xl border border-border">
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-border text-left text-sm">
+              <thead className="bg-muted/40 text-xs uppercase tracking-wide text-mutedfg">
+                <tr>
+                  <th className="px-4 py-3 font-semibold">SKU</th>
+                  <th className="px-4 py-3 font-semibold">Name</th>
+                  <th className="px-4 py-3 font-semibold">On hand</th>
+                  <th className="px-4 py-3 font-semibold">Min / Max</th>
+                  <th className="px-4 py-3 font-semibold">Vendor</th>
+                  <th className="px-4 py-3 font-semibold">Cost</th>
+                  <th className="px-4 py-3" />
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {isLoading && (
+                  <tr>
+                    <td colSpan={7} className="px-4 py-6">
+                      <div className="space-y-2">
+                        {Array.from({ length: 4 }).map((_, index) => (
+                          <div key={index} className="h-6 animate-pulse rounded bg-muted" />
+                        ))}
+                      </div>
+                    </td>
+                  </tr>
+                )}
+                {!isLoading && parts.length === 0 && (
+                  <tr>
+                    <td colSpan={7} className="px-4 py-6 text-center text-sm text-mutedfg">
+                      No parts have been added yet.
+                    </td>
+                  </tr>
+                )}
+                {!isLoading &&
+                  parts.map((part) => (
+                    <tr key={part.id} className="hover:bg-muted/30">
+                      <td className="whitespace-nowrap px-4 py-3 font-semibold text-fg">{part.sku}</td>
+                      <td className="px-4 py-3 text-mutedfg">
+                        <div>{part.name}</div>
+                        {part.description && <div className="text-xs">{part.description}</div>}
+                      </td>
+                      <td className="px-4 py-3 text-mutedfg">
+                        <div className="font-semibold text-fg">{part.onHand}</div>
+                        {part.onOrder > 0 && <div className="text-xs">{part.onOrder} on order</div>}
+                      </td>
+                      <td className="px-4 py-3 text-mutedfg">
+                        {part.min} / {part.max}
+                      </td>
+                      <td className="px-4 py-3 text-mutedfg">{part.vendor?.name ?? '—'}</td>
+                      <td className="px-4 py-3 text-mutedfg">
+                        {part.cost != null ? `$${part.cost.toFixed(2)}` : '—'}
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => openDrawer('edit', part)}
+                          className="rounded-xl"
+                        >
+                          Edit
+                        </Button>
+                      </td>
+                    </tr>
+                  ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+
       <section className="rounded-3xl border border-dashed border-border bg-muted/40 p-10 text-center text-sm text-mutedfg">
         <p className="font-semibold text-fg">Upcoming: predictive inventory</p>
-        <p className="mt-2">Forecast consumption and automate reorders with lead time insights. Contact your account team to join the beta.</p>
+        <p className="mt-2">
+          Forecast consumption and automate reorders with lead time insights. Contact your account team to join the beta.
+        </p>
       </section>
+
+      <SlideOver
+        open={drawerOpen}
+        title={drawerMode === 'create' ? 'Add part' : `Edit ${activePart?.name ?? 'part'}`}
+        description={drawerMode === 'create' ? 'Capture key details about a new spare part.' : 'Update thresholds and costing.'}
+        onClose={closeDrawer}
+        width="lg"
+      >
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <label className="text-sm font-semibold text-mutedfg">
+              SKU
+              <Input
+                value={formState.sku}
+                onChange={(event) => handleFormChange('sku', event.target.value)}
+                className="mt-2"
+                placeholder="e.g. PUMP-SEAL-001"
+              />
+            </label>
+            <label className="text-sm font-semibold text-mutedfg">
+              Name
+              <Input
+                value={formState.name}
+                onChange={(event) => handleFormChange('name', event.target.value)}
+                className="mt-2"
+                placeholder="Part name"
+              />
+            </label>
+          </div>
+          <label className="block text-sm font-semibold text-mutedfg">
+            Description
+            <textarea
+              value={formState.description}
+              onChange={(event) => handleFormChange('description', event.target.value)}
+              className="mt-2 h-24 w-full rounded-2xl border border-border bg-white px-4 py-3 text-sm text-fg shadow-inner focus:outline-none focus:ring-2 focus:ring-brand"
+              placeholder="Optional details to help identify this part"
+            />
+          </label>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+            <label className="text-sm font-semibold text-mutedfg">
+              Min level
+              <Input
+                value={formState.min}
+                onChange={(event) => handleFormChange('min', event.target.value)}
+                className="mt-2"
+                inputMode="numeric"
+                placeholder="0"
+              />
+            </label>
+            <label className="text-sm font-semibold text-mutedfg">
+              Max level
+              <Input
+                value={formState.max}
+                onChange={(event) => handleFormChange('max', event.target.value)}
+                className="mt-2"
+                inputMode="numeric"
+                placeholder="0"
+              />
+            </label>
+            <label className="text-sm font-semibold text-mutedfg">
+              On hand
+              <Input
+                value={formState.onHand}
+                onChange={(event) => handleFormChange('onHand', event.target.value)}
+                className="mt-2"
+                inputMode="numeric"
+                placeholder="0"
+                disabled={drawerMode === 'edit'}
+              />
+            </label>
+          </div>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+            <label className="text-sm font-semibold text-mutedfg">
+              Unit cost
+              <Input
+                value={formState.cost}
+                onChange={(event) => handleFormChange('cost', event.target.value)}
+                className="mt-2"
+                inputMode="decimal"
+                placeholder="0.00"
+              />
+            </label>
+            <label className="text-sm font-semibold text-mutedfg">
+              Unit of measure
+              <Input
+                value={formState.unitOfMeasure}
+                onChange={(event) => handleFormChange('unitOfMeasure', event.target.value)}
+                className="mt-2"
+                placeholder="e.g. ea, box"
+              />
+            </label>
+            <label className="text-sm font-semibold text-mutedfg">
+              Vendor ID
+              <Input
+                value={formState.vendorId}
+                onChange={(event) => handleFormChange('vendorId', event.target.value)}
+                className="mt-2"
+                placeholder="Optional"
+              />
+            </label>
+          </div>
+
+          {formError && <p className="text-sm text-destructive">{formError}</p>}
+
+          <div className="flex justify-end gap-3">
+            <Button type="button" variant="outline" onClick={closeDrawer} className="rounded-xl">
+              Cancel
+            </Button>
+            <Button type="submit" className="rounded-xl bg-brand text-white" disabled={saving}>
+              {saving ? 'Saving...' : 'Save changes'}
+            </Button>
+          </div>
+        </form>
+      </SlideOver>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- expand the Prisma inventory schema with vendor, warehouse, stock level, and purchase order entities to support richer stock tracking
- implement authenticated parts and purchase-order routers that cover CRUD, adjustments, receipts, and on-order recalculation, plus a reusable warehouse helper
- replace the Inventory page mock data with live queries and mutations backed by the new API, including create/edit panels and low-stock alerts

## Testing
- npm run build (backend)
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1027e8c988323af3297a01b5fb4b5