### PR TITLE
Fix asset lifecycle handlers

### DIFF
--- a/backend/src/routes/assets.ts
+++ b/backend/src/routes/assets.ts
@@ -309,11 +309,50 @@ router.put(
 
     const payload = assetPayloadSchema.parse(req.body);
 
-    if (!asset) {
+    const scope = buildTenantScope({ tenantId: req.user.tenantId, siteId: req.user.siteId ?? null });
+    const existing = await prisma.asset.findFirst({
+      where: { id: req.params.id, ...scope },
+      select: { id: true },
+    });
+
+    if (!existing) {
       return fail(res, 404, 'Asset not found');
     }
 
-    return ok(res, serializeAssetLifecycle(asset));
+    const data: Prisma.AssetUpdateInput = {
+      code: payload.code,
+      name: payload.name,
+    };
+
+    if (payload.location !== undefined) {
+      data.location = payload.location;
+    }
+    if (payload.category !== undefined) {
+      data.category = payload.category;
+    }
+    if (payload.purchaseDate !== undefined) {
+      data.purchaseDate = payload.purchaseDate;
+    }
+    if (payload.cost !== undefined) {
+      data.cost = payload.cost;
+    }
+    if (payload.status !== undefined) {
+      data.status = payload.status;
+    }
+
+    const updated = await prisma.asset.update({
+      where: { id: existing.id },
+      data,
+      include: {
+        site: true,
+        area: true,
+        line: true,
+        station: true,
+        bomItems: true,
+      },
+    });
+
+    return ok(res, serializeAssetLifecycle(updated));
   }),
 );
 
@@ -324,28 +363,23 @@ router.get(
       return fail(res, 401, 'Authentication required');
     }
 
-    const existing = await prisma.asset.findFirst({
+    const scope = buildTenantScope({ tenantId: req.user.tenantId, siteId: req.user.siteId ?? null });
+    const asset = await prisma.asset.findFirst({
       where: { id: req.params.id, ...scope },
-    });
-
-    if (!existing) {
-      return res.status(404).json({ ok: false, error: 'Asset not found' });
-    }
-
-    const updated = await prisma.asset.update({
-      where: { id: existing.id },
-      data: {
-        code: payload.code,
-        name: payload.name,
-        location: payload.location,
-        category: payload.category,
-        purchaseDate: payload.purchaseDate,
-        cost: payload.cost,
-        status: payload.status ?? existing.status,
+      include: {
+        site: true,
+        area: true,
+        line: true,
+        station: true,
+        bomItems: true,
       },
     });
 
-    return res.json({ ok: true, asset: serializeAsset(updated) });
+    if (!asset) {
+      return fail(res, 404, 'Asset not found');
+    }
+
+    return ok(res, serializeAssetLifecycle(asset));
   }),
 );
 


### PR DESCRIPTION
## Summary
- scope the asset update route to the tenant/site and apply updates before returning lifecycle data
- load lifecycle information for an asset without mutating records when reading lifecycle details

## Testing
- pnpm --filter workpro-backend build *(fails: No projects matched the filters in this workspace)*
- pnpm build *(fails: pre-existing TypeScript error in backend/src/routes/assets.ts at line 62)*

------
https://chatgpt.com/codex/tasks/task_e_68e1f6d74a808323afb7b2a4c8e15a95