### PR TITLE
Fix Dashboard data formatting and smoke test

### DIFF
--- a/src/pages/Dashboard.test.tsx
+++ b/src/pages/Dashboard.test.tsx
@@ -1,11 +1,45 @@
 import React from 'react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderToString } from 'react-dom/server';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import Dashboard from './Dashboard';
 
+const mockApiGet = vi.hoisted(() => vi.fn());
+const mockWorkOrdersList = vi.hoisted(() => vi.fn());
+
+vi.mock('../lib/api', () => ({
+  api: {
+    get: mockApiGet,
+  },
+}));
+
+vi.mock('../lib/workOrdersApi', () => ({
+  workOrdersApi: {
+    list: mockWorkOrdersList,
+  },
+}));
+
 describe('Dashboard page', () => {
+  beforeEach(() => {
+    mockApiGet.mockReset();
+    mockWorkOrdersList.mockReset();
+
+    mockApiGet.mockResolvedValue({
+      kpis: {
+        openWorkOrders: {
+          total: 0,
+          byPriority: { critical: 0, high: 0, medium: 0, low: 0 },
+          delta7d: 0,
+        },
+        mttrHours: { value: 0, delta30d: 0 },
+        uptimePct: { value: 0, delta30d: 0 },
+        stockoutRisk: { count: 0, items: [] },
+      },
+    });
+
+    mockWorkOrdersList.mockResolvedValue({ items: [] });
+  });
+
   it('renders without throwing', () => {
     const queryClient = new QueryClient();
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,11 +1,13 @@
 import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { ArrowRight, BellRing, Building2, ClipboardList, ShieldCheck, Users, Wrench } from 'lucide-react';
+import { AlertTriangle, ArrowRight, BellRing, Building2, ClipboardList, ShieldCheck, Users, Wrench } from 'lucide-react';
 import { KPICard } from '../components/premium/KPICard';
 import { DataBadge } from '../components/premium/DataBadge';
 import { ProTable, type ProTableColumn } from '../components/premium/ProTable';
 import { EmptyState } from '../components/premium/EmptyState';
 import { api } from '../lib/api';
+import { workOrdersApi } from '../lib/workOrdersApi';
+import { formatDate, formatWorkOrderPriority, formatWorkOrderStatus } from '../lib/utils';
 import { normalizeWorkOrders, type WorkOrderRecord } from '../lib/workOrders';
 
 type PriorityBuckets = Record<'critical' | 'high' | 'medium' | 'low', number>;
@@ -85,7 +87,7 @@ const columns: ProTableColumn<WorkOrderRecord>[] = [
   {
     key: 'status',
     header: 'Status',
-    accessor: (row) => <DataBadge status={row.statusLabel} />
+    accessor: (row) => <DataBadge status={formatWorkOrderStatus(row.status ?? '')} />
   },
   { key: 'critical', header: 'Critical', align: 'right' },
   { key: 'high', header: 'High', align: 'right' },
@@ -94,7 +96,7 @@ const columns: ProTableColumn<WorkOrderRecord>[] = [
   {
     key: 'priority',
     header: 'Priority',
-    accessor: (row) => <DataBadge status={row.priorityLabel} />
+    accessor: (row) => <DataBadge status={formatWorkOrderPriority(row.priority ?? '')} />
   },
   {
     key: 'assignee',
@@ -156,8 +158,8 @@ export default function Dashboard() {
   } = useQuery<WorkOrderRecord[]>({
     queryKey: ['dashboard', 'work-orders-preview'],
     queryFn: async () => {
-      const response = await api.get<unknown>('/work-orders');
-      return normalizeWorkOrders(response).slice(0, 8);
+      const response = await workOrdersApi.list({ limit: 8 });
+      return normalizeWorkOrders(response.items ?? []);
     },
     staleTime: 60_000,
     retry: false,
@@ -216,12 +218,12 @@ export default function Dashboard() {
 
   return (
     <div className="space-y-10">
-      {isError && (
+      {metricsError && (
         <div className="flex items-start gap-3 p-5 text-sm border rounded-3xl border-danger/40 bg-danger/5 text-danger">
           <AlertTriangle className="mt-0.5 h-5 w-5 flex-shrink-0" />
           <div>
             <p className="text-base font-semibold">Unable to load dashboard metrics</p>
-            <p className="mt-1 text-danger/80">{errorMessage}</p>
+            <p className="mt-1 text-danger/80">{metricsErrorMessage}</p>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- update the Dashboard page to source helper utilities from the dedicated modules and format status/priority from real data
- rely on the workOrdersApi preview endpoint and clean up metrics error handling
- add a Dashboard smoke test that mocks the data sources and renders without throwing

## Testing
- pnpm vitest run src/pages/Dashboard.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e1f6df37508323a08234ed6a772e66