### PR TITLE
Remove duplicate work order formatter definitions

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -34,21 +34,6 @@ export function cn(...classes: (string | undefined | null | false)[]): string {
   return classes.filter(Boolean).join(' ');
 }
 
-
-export function formatWorkOrderStatus(value: string): string {
-  const normalized = value.replace(/_/g, ' ').trim();
-  return normalized.replace(/\b\w/g, (char) => char.toUpperCase());
-}
-
-export function formatWorkOrderPriority(value: string): string {
-  if (!value) {
-    return '';
-  }
-
-  const lower = value.toLowerCase();
-  return lower.charAt(0).toUpperCase() + lower.slice(1);
-}
-
 export function toTitleCase(value: string): string {
   if (!value) {
     return '';


### PR DESCRIPTION
## Summary
- remove the redundant work order formatter implementations from `src/lib/utils.ts`
- rely on the single source implementations exported from `src/lib/format.ts`

## Testing
- npm run typecheck *(fails: Cannot find type definition file for 'vite/client' and 'vitest/globals')*


------
https://chatgpt.com/codex/tasks/task_e_68e2081b7a948323afa1bc5e3c8d917d