### PR TITLE
Use xlsx utilities for WorkOrders exports

### DIFF
--- a/src/pages/WorkOrders.tsx
+++ b/src/pages/WorkOrders.tsx
@@ -15,7 +15,7 @@ import { normalizeWorkOrders, type WorkOrderRecord } from '../lib/workOrders';
 import { useToast } from '@/components/ui/toast';
 import { useCan } from '@/lib/rbac';
 import { toTitleCase } from '@/lib/utils';
-import { writeFile, read } from 'fs';
+import { read, utils, writeFile } from 'xlsx';
 
 type QueryState = {
   page: number;


### PR DESCRIPTION
## Summary
- replace the Node `fs` import in the WorkOrders page with the browser-friendly `xlsx` helpers
- keep the existing `utils` usages by sourcing them from the `xlsx` module

## Testing
- npm run typecheck *(fails: TypeScript references expect `vite.config.d.ts` output even in --noEmit mode)*

------
https://chatgpt.com/codex/tasks/task_e_68e21cf73d9083239fffb3d496a94e9a