### PR TITLE
Add VS Code CSS lint rule overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ dist-ssr
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
+!.vscode/settings.json
 .idea
 .DS_Store
 *.suo

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "css.lint.unknownAtRules": "ignore",
+  "scss.lint.unknownAtRules": "ignore",
+  "less.lint.unknownAtRules": "ignore"
+}


### PR DESCRIPTION
## Summary
- allow committing shared VS Code configuration
- add settings to ignore unknown at-rule lint errors in CSS-family files

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2286770e88323b40ec722ad690683