### PR TITLE
Handle missing API error messages in work order view

### DIFF
--- a/src/pages/WorkOrderDetails.tsx
+++ b/src/pages/WorkOrderDetails.tsx
@@ -48,7 +48,7 @@ export default function WorkOrderDetails() {
   const statusLabel = workOrder ? formatWorkOrderStatus(workOrder.status) : null;
   const errorMessage = isError
     ? isApiErrorResponse(error)
-      ? error.error.message
+      ? error.error?.message ?? 'Unable to load work order details'
       : 'Unable to load work order details'
     : null;
 


### PR DESCRIPTION
## Summary
- update the work order details error message handling to gracefully fall back when the API response is missing a message

## Testing
- npm run typecheck *(fails: missing vite/client and vitest/globals type definitions and stale vite.config.d.ts reference)*

------
https://chatgpt.com/codex/tasks/task_e_68e2286a133083238f350f008e1e888d