### PR TITLE
Add offline flag to ApiError and type axios interceptors

### DIFF
--- a/shared/types/http.ts
+++ b/shared/types/http.ts
@@ -2,6 +2,7 @@ export interface ApiError {
   code: number;
   message: string;
   details?: unknown;
+  offline?: boolean;
 }
 
 export interface ApiResponse<T> {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -4,9 +4,10 @@ import axios, {
   type AxiosInstance,
   type AxiosRequestConfig,
   type AxiosResponse,
+  type InternalAxiosRequestConfig,
   isAxiosError,
 } from 'axios';
-import type { ApiError, ApiResponse } from '../../shared/types/http';
+import type { ApiResponse } from '../../shared/types/http';
 import {
   ApiRequestError,
   isApiErrorResponse,
@@ -125,7 +126,7 @@ function applyDefaultAuthorization(token: string | null) {
   }
 }
 
-httpClient.interceptors.request.use((config) => {
+httpClient.interceptors.request.use((config: InternalAxiosRequestConfig) => {
   const token = getToken();
   if (token) {
     const headers =
@@ -140,8 +141,8 @@ httpClient.interceptors.request.use((config) => {
 });
 
 httpClient.interceptors.response.use(
-  (response) => response,
-  (error) => {
+  (response: AxiosResponse<ApiResponse<unknown>>) => response,
+  (error: AxiosError<ApiResponse<unknown>>) => {
     if (isAxiosError(error)) {
       const status = error.response?.status;
       if (status === 401 || status === 403) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import { VitePWA } from 'vite-plugin-pwa'
 


### PR DESCRIPTION
## Summary
- add an optional offline flag to the shared ApiError interface
- tighten axios interceptor typings to use InternalAxiosRequestConfig and ApiResponse-aware responses
- switch the Vite config to vitest's defineConfig helper so Vitest settings remain type-safe

## Testing
- `npm run typecheck` *(fails: existing repository TypeScript errors in UI and test files)*

------
https://chatgpt.com/codex/tasks/task_e_68e2286a51d883239ddb2df2d7cf14a7