### PR TITLE
Refine work orders test mocks and adjust Vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import { VitePWA } from 'vite-plugin-pwa'
 


### PR DESCRIPTION
## Summary
- hoist the shared work order fixtures and merge the API mock within the WorkOrders e2e test
- type the mocked records with WorkOrderListItem and keep imports at the top of the test file
- source Vite defineConfig from vitest/config so the Vitest options type-check correctly

## Testing
- npm run typecheck *(fails: existing project-wide TypeScript errors unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68e2286c44388323a4d417ce7cd04931