### PR TITLE
Fix WorkOrders import input detection in e2e test

### DIFF
--- a/src/pages/WorkOrders.e2e.test.tsx
+++ b/src/pages/WorkOrders.e2e.test.tsx
@@ -315,7 +315,16 @@ describe('WorkOrders page', () => {
     const inputs = screen.getAllByTestId('work-orders-import-input') as HTMLInputElement[];
     const targetInput = inputs.find((element) => {
       const reactKey = Object.keys(element).find((key) => key.startsWith('__reactProps$'));
-      return Boolean(reactKey && (element as Record<string, { onChange?: unknown }>)[reactKey]?.onChange);
+      if (!reactKey) {
+        return false;
+      }
+
+      const props = (element as unknown as Record<string, unknown>)[reactKey];
+      if (!props || typeof props !== 'object') {
+        return false;
+      }
+
+      return typeof (props as { onChange?: unknown }).onChange === 'function';
     });
     if (!targetInput) {
       throw new Error('Unable to locate file input with onChange handler');


### PR DESCRIPTION
## Summary
- update WorkOrders import e2e test to safely inspect react props before accessing onChange
- ensure the predicate only returns true when an onChange function is found

## Testing
- npm run typecheck *(fails: existing type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e22e0f5da883238990c8a613496c24