### PR TITLE
Handle missing API error messages in work orders

### DIFF
--- a/src/pages/WorkOrders.tsx
+++ b/src/pages/WorkOrders.tsx
@@ -247,7 +247,7 @@ export default function WorkOrders() {
 
   const queryErrorMessage = isError
     ? isApiErrorResponse(error)
-      ? error.error.message
+      ? error.error?.message ?? 'Unable to load work orders'
       : errorMessage(error, 'Unable to load work orders')
     : null;
 


### PR DESCRIPTION
## Summary
- ensure the WorkOrders query error message tolerates missing API error payloads by using optional chaining and a fallback string

## Testing
- npm run typecheck *(fails: existing TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e22e10e8d083238fc2f95b7981f7b4