### PR TITLE
Add explicit request typings to service worker route predicates

### DIFF
--- a/src/sw.ts
+++ b/src/sw.ts
@@ -54,7 +54,7 @@ async function broadcastQueueState(
 }
 
 registerRoute(
-  ({ request }) => request.mode === 'navigate',
+  ({ request }: { request: Request }) => request.mode === 'navigate',
   new NetworkFirst({
     cacheName: PAGE_CACHE,
     networkTimeoutSeconds: 5,
@@ -66,7 +66,7 @@ registerRoute(
 );
 
 registerRoute(
-  ({ request }) => ['style', 'script', 'font'].includes(request.destination),
+  ({ request }: { request: Request }) => ['style', 'script', 'font'].includes(request.destination),
   new StaleWhileRevalidate({
     cacheName: CORE_CACHE,
     plugins: [
@@ -77,7 +77,7 @@ registerRoute(
 );
 
 registerRoute(
-  ({ url, request }) => {
+  ({ url, request }: { url: URL; request: Request }) => {
     if (request.method !== 'GET') {
       return false;
     }


### PR DESCRIPTION
## Summary
- add explicit Request and URL typings to the Workbox registerRoute predicate callbacks to satisfy TS7031

## Testing
- npm run typecheck *(fails: existing TypeScript issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e22e1316d88323ac4d01940a9f87a7