### PR TITLE
Handle missing API error message in work orders

### DIFF
--- a/src/pages/WorkOrders.tsx
+++ b/src/pages/WorkOrders.tsx
@@ -247,7 +247,7 @@ export default function WorkOrders() {
 
   const queryErrorMessage = isError
     ? isApiErrorResponse(error)
-      ? error.error.message
+      ? error.error?.message ?? 'Unable to load work orders'
       : errorMessage(error, 'Unable to load work orders')
     : null;
 


### PR DESCRIPTION
## Summary
- ensure the work orders query error message tolerates missing API error payloads by using optional chaining and a default fallback

## Testing
- npm run typecheck *(fails: pre-existing TypeScript errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e22e1364c08323ac5dc445c2514b6a