### PR TITLE
Add assets API helpers and tests

### DIFF
--- a/src/lib/assets.test.ts
+++ b/src/lib/assets.test.ts
@@ -1,0 +1,198 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AxiosResponse } from 'axios';
+import type { ApiResponse } from '../../shared/types/http';
+
+function createAxiosResponse<T>(payload: ApiResponse<T>): AxiosResponse<ApiResponse<T>> {
+  return {
+    data: payload,
+    status: 200,
+    statusText: 'OK',
+    headers: {},
+    config: {},
+  } as AxiosResponse<ApiResponse<T>>;
+}
+
+describe('assets api helpers', () => {
+  let assetsModule: typeof import('./assets');
+  let apiModule: typeof import('./api');
+
+  beforeEach(async () => {
+    vi.resetModules();
+    apiModule = await import('./api');
+    assetsModule = await import('./assets');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('lists assets with cleaned query parameters', async () => {
+    const getSpy = vi
+      .spyOn(apiModule.httpClient, 'get')
+      .mockResolvedValue(
+        createAxiosResponse({
+          data: { assets: [], meta: { page: 1, pageSize: 10, total: 0, totalPages: 1 } },
+          error: null,
+        }),
+      );
+
+    await assetsModule.listAssets({
+      page: 2,
+      pageSize: 25,
+      search: 'pump',
+      status: '',
+      location: 'Plant 1',
+      category: 'Utilities',
+      sort: 'createdAt:desc',
+    });
+
+    expect(getSpy).toHaveBeenCalledWith('/assets', {
+      params: {
+        page: 2,
+        pageSize: 25,
+        search: 'pump',
+        location: 'Plant 1',
+        category: 'Utilities',
+        sort: 'createdAt:desc',
+      },
+    });
+  });
+
+  it('creates an asset with the provided payload', async () => {
+    const asset = {
+      id: 'asset-1',
+      code: 'PUMP-1',
+      name: 'Pump',
+      status: 'operational',
+      location: 'Plant',
+      category: 'Utilities',
+      purchaseDate: new Date().toISOString(),
+      cost: 1000,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    } as const;
+
+    const postSpy = vi
+      .spyOn(apiModule.httpClient, 'post')
+      .mockResolvedValue(createAxiosResponse({ data: { asset }, error: null }));
+
+    const payload = {
+      name: 'Pump',
+      code: 'PUMP-1',
+      status: 'operational' as const,
+      location: 'Plant',
+      category: 'Utilities',
+      purchaseDate: asset.purchaseDate,
+      cost: 1000,
+    };
+
+    const result = await assetsModule.createAsset(payload);
+
+    expect(postSpy).toHaveBeenCalledWith('/assets', payload);
+    expect(result).toEqual(asset);
+  });
+
+  it('updates an asset by id', async () => {
+    const asset = {
+      id: 'asset-1',
+      code: 'PUMP-1',
+      name: 'Pump',
+      status: 'operational',
+      location: 'Plant',
+      category: 'Utilities',
+      purchaseDate: new Date().toISOString(),
+      cost: 1000,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    } as const;
+
+    const putSpy = vi
+      .spyOn(apiModule.httpClient, 'put')
+      .mockResolvedValue(createAxiosResponse({ data: { asset }, error: null }));
+
+    const update = { name: 'Updated Pump', category: 'Maintenance' };
+    const result = await assetsModule.updateAsset(asset.id, update);
+
+    expect(putSpy).toHaveBeenCalledWith(`/assets/${asset.id}`, update);
+    expect(result).toEqual(asset);
+  });
+
+  it('deletes an asset by id', async () => {
+    const asset = {
+      id: 'asset-1',
+      code: 'PUMP-1',
+      name: 'Pump',
+      status: 'operational',
+      location: 'Plant',
+      category: 'Utilities',
+      purchaseDate: new Date().toISOString(),
+      cost: 1000,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    } as const;
+
+    const deleteSpy = vi
+      .spyOn(apiModule.httpClient, 'delete')
+      .mockResolvedValue(createAxiosResponse({ data: { asset }, error: null }));
+
+    const result = await assetsModule.deleteAsset(asset.id);
+
+    expect(deleteSpy).toHaveBeenCalledWith(`/assets/${asset.id}`);
+    expect(result).toEqual(asset);
+  });
+
+  it('imports assets in bulk', async () => {
+    const asset = {
+      id: 'asset-1',
+      code: 'PUMP-1',
+      name: 'Pump',
+      status: 'operational',
+      location: 'Plant',
+      category: 'Utilities',
+      purchaseDate: new Date().toISOString(),
+      cost: 1000,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    } as const;
+
+    const postSpy = vi
+      .spyOn(apiModule.httpClient, 'post')
+      .mockResolvedValue(createAxiosResponse({ data: { assets: [asset] }, error: null }));
+
+    const payload = {
+      assets: [
+        {
+          name: 'Pump',
+          code: 'PUMP-1',
+          status: 'operational' as const,
+        },
+      ],
+    };
+
+    const result = await assetsModule.importAssets(payload);
+
+    expect(postSpy).toHaveBeenCalledWith('/assets/import', payload);
+    expect(result).toEqual([asset]);
+  });
+
+  it('exports assets as a blob', async () => {
+    const blob = new Blob(['test'], { type: 'text/plain' });
+    const getSpy = vi
+      .spyOn(apiModule.httpClient, 'get')
+      .mockResolvedValue({
+        data: blob,
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {},
+      } as AxiosResponse<Blob>);
+
+    const result = await assetsModule.exportAssets({ search: 'pump', status: '' });
+
+    expect(getSpy).toHaveBeenCalledWith('/assets/export', {
+      params: { search: 'pump' },
+      responseType: 'blob',
+    });
+    expect(result).toBe(blob);
+  });
+});

--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -1,0 +1,128 @@
+import type { ApiResponse } from '../../shared/types/http';
+import { httpClient, unwrapResponse } from './api';
+
+export const assetStatuses = ['operational', 'maintenance', 'down', 'retired', 'decommissioned'] as const;
+
+export type AssetStatus = (typeof assetStatuses)[number];
+
+export interface AssetRecord {
+  id: string;
+  code: string;
+  name: string;
+  status: AssetStatus;
+  location: string | null;
+  category: string | null;
+  purchaseDate: string | null;
+  cost: number | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AssetListMeta {
+  page: number;
+  pageSize: number;
+  total: number;
+  totalPages: number;
+}
+
+export interface AssetsResponse {
+  assets: AssetRecord[];
+  meta: AssetListMeta;
+}
+
+export interface AssetQuery {
+  page?: number;
+  pageSize?: number;
+  search?: string;
+  status?: AssetStatus | '';
+  location?: string;
+  category?: string;
+  sort?: string;
+}
+
+export interface SaveAssetPayload {
+  name: string;
+  code: string;
+  status: AssetStatus;
+  location?: string;
+  category?: string;
+  purchaseDate?: string;
+  cost?: number;
+}
+
+export interface ImportAssetsPayload {
+  assets: SaveAssetPayload[];
+}
+
+function withCleanParams(params: AssetQuery): Record<string, string | number | undefined> {
+  const entries = Object.entries(params).filter(([, value]) => {
+    if (value === undefined || value === null) {
+      return false;
+    }
+
+    if (typeof value === 'string' && value.trim() === '') {
+      return false;
+    }
+
+    return true;
+  });
+
+  return Object.fromEntries(entries) as Record<string, string | number | undefined>;
+}
+
+export async function listAssets(query: AssetQuery): Promise<AssetsResponse> {
+  return unwrapResponse(
+    httpClient.get<ApiResponse<AssetsResponse>>('/assets', {
+      params: withCleanParams(query),
+    }),
+  );
+}
+
+export async function getAsset(id: string): Promise<AssetRecord> {
+  const response = await unwrapResponse<{ asset: AssetRecord }>(
+    httpClient.get<ApiResponse<{ asset: AssetRecord }>>(`/assets/${id}`),
+  );
+
+  return response.asset;
+}
+
+export async function createAsset(payload: SaveAssetPayload): Promise<AssetRecord> {
+  const response = await unwrapResponse<{ asset: AssetRecord }>(
+    httpClient.post<ApiResponse<{ asset: AssetRecord }>>('/assets', payload),
+  );
+
+  return response.asset;
+}
+
+export async function updateAsset(id: string, payload: Partial<SaveAssetPayload>): Promise<AssetRecord> {
+  const response = await unwrapResponse<{ asset: AssetRecord }>(
+    httpClient.put<ApiResponse<{ asset: AssetRecord }>>(`/assets/${id}`, payload),
+  );
+
+  return response.asset;
+}
+
+export async function deleteAsset(id: string): Promise<AssetRecord> {
+  const response = await unwrapResponse<{ asset: AssetRecord }>(
+    httpClient.delete<ApiResponse<{ asset: AssetRecord }>>(`/assets/${id}`),
+  );
+
+  return response.asset;
+}
+
+export async function importAssets(payload: ImportAssetsPayload): Promise<AssetRecord[]> {
+  const response = await unwrapResponse<{ assets: AssetRecord[] }>(
+    httpClient.post<ApiResponse<{ assets: AssetRecord[] }>>('/assets/import', payload),
+  );
+
+  return response.assets;
+}
+
+export async function exportAssets(query: AssetQuery): Promise<Blob> {
+  const { data } = await httpClient.get<Blob>('/assets/export', {
+    params: withCleanParams(query),
+    responseType: 'blob',
+  });
+
+  return data;
+}


### PR DESCRIPTION
## Summary
- add a dedicated assets API helper module with list/create/update/delete/import/export utilities
- refactor the assets page to consume the shared helpers
- update the assets page tests and add coverage for the new helpers

## Testing
- pnpm test -- --run *(fails: vitest binary missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e26b09295c8323951ff605d5bd0d63