### PR TITLE
feat(frontend): add offline cache and background sync support

### DIFF
--- a/frontend/public/service-worker.js
+++ b/frontend/public/service-worker.js
@@ -1,0 +1,145 @@
+const DB_NAME = 'workpro-sync';
+const STORE_NAME = 'queued-mutations';
+const DEFAULT_SYNC_TAG = 'workpro-mutation-sync';
+
+function openDatabase() {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1);
+
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: 'clientId' });
+      }
+    };
+
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => resolve(request.result);
+  });
+}
+
+async function withStore(mode, callback) {
+  const db = await openDatabase();
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, mode);
+    const store = transaction.objectStore(STORE_NAME);
+    const request = callback(store);
+
+    transaction.oncomplete = () => resolve(request?.result);
+    transaction.onerror = () => reject(transaction.error);
+  });
+}
+
+function putMutation(entry) {
+  return withStore('readwrite', (store) => store.put(entry));
+}
+
+function deleteMutation(clientId) {
+  return withStore('readwrite', (store) => store.delete(clientId));
+}
+
+async function getAllMutations() {
+  const db = await openDatabase();
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, 'readonly');
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.getAll();
+    request.onsuccess = () => resolve(request.result || []);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+async function notifyClients(type, payload) {
+  const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+  clients.forEach((client) => {
+    client.postMessage({ type, payload });
+  });
+}
+
+async function processQueue(tag) {
+  const mutations = await getAllMutations();
+
+  for (const mutation of mutations) {
+    if (mutation.tag && mutation.tag !== tag) {
+      continue;
+    }
+
+    try {
+      const response = await fetch(mutation.endpoint, {
+        method: mutation.method || 'POST',
+        headers: mutation.headers || {},
+        body: mutation.body ? JSON.stringify(mutation.body) : undefined,
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to sync mutation: ${response.status}`);
+      }
+
+      await deleteMutation(mutation.clientId);
+
+      let responseBody = null;
+      try {
+        responseBody = await response.clone().json();
+      } catch (error) {
+        responseBody = null;
+      }
+
+      await notifyClients('mutation-synced', {
+        clientId: mutation.clientId,
+        entity: mutation.entity,
+        response: responseBody,
+      });
+    } catch (error) {
+      console.error('Background sync failed', error);
+      throw error;
+    }
+  }
+}
+
+self.addEventListener('install', (event) => {
+  self.skipWaiting();
+  event.waitUntil(openDatabase());
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('message', (event) => {
+  const { data } = event;
+  if (!data || data.type !== 'queue-mutation') {
+    return;
+  }
+
+  const entry = {
+    clientId: data.payload.clientId,
+    endpoint: data.payload.endpoint,
+    method: data.payload.method,
+    headers: data.payload.headers,
+    body: data.payload.body,
+    entity: data.payload.entity,
+    tag: data.payload.tag || DEFAULT_SYNC_TAG,
+  };
+
+  event.waitUntil(
+    (async () => {
+      await putMutation(entry);
+      if (self.registration.sync && typeof self.registration.sync.register === 'function') {
+        try {
+          await self.registration.sync.register(entry.tag);
+        } catch (error) {
+          console.warn('Unable to register background sync', error);
+        }
+      }
+    })(),
+  );
+});
+
+self.addEventListener('sync', (event) => {
+  if (event.tag === DEFAULT_SYNC_TAG) {
+    event.waitUntil(processQueue(DEFAULT_SYNC_TAG));
+    return;
+  }
+
+  event.waitUntil(processQueue(event.tag));
+});

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { BrowserRouter, Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
@@ -5,6 +6,7 @@ import { Layout } from './components/Layout';
 import { AuthProvider, useAuth } from './hooks/useAuth';
 import ErrorBoundary from './components/ErrorBoundary';
 import { Toaster } from '@/components/ui/toaster';
+import { registerServiceWorker } from './serviceWorker';
 import { Dashboard } from './pages/Dashboard';
 import { WorkOrders } from './pages/WorkOrders';
 import { Assets } from './pages/Assets';
@@ -70,6 +72,10 @@ function AppRoutes() {
 }
 
 function App() {
+  useEffect(() => {
+    registerServiceWorker();
+  }, []);
+
   return (
     <QueryClientProvider client={queryClient}>
       <AuthProvider>

--- a/frontend/src/components/work-orders/WorkOrderForm.jsx
+++ b/frontend/src/components/work-orders/WorkOrderForm.jsx
@@ -18,7 +18,9 @@ const fileSchema = z.custom(
   },
 );
 
-const OBJECT_ID_REGEX = /^[a-fA-F0-9]{24}$/;`r`n`r`nconst workOrderSchema = z.object({
+const OBJECT_ID_REGEX = /^[a-fA-F0-9]{24}$/;
+
+const workOrderSchema = z.object({
   title: z.string().min(1, 'Title is required'),
   description: z
     .string()
@@ -55,11 +57,9 @@ const DEFAULT_VALUES = {
   assetId: '',
   lineName: '',
   stationNumber: '',
-
-
 };
 
-export function WorkOrderForm({ onClose, onSuccess, defaultValues, asset: assetProp }) {
+export function WorkOrderForm({ onClose, onSuccess, onQueued, defaultValues, asset: assetProp }) {
 
   const [submitError, setSubmitError] = useState('');
   const { toast } = useToast();
@@ -190,6 +190,26 @@ export function WorkOrderForm({ onClose, onSuccess, defaultValues, asset: assetP
         onClose();
       }
     } catch (error) {
+      const isOffline =
+        (typeof navigator !== 'undefined' && navigator.onLine === false) ||
+        error?.code === 'ERR_NETWORK' ||
+        (typeof error?.message === 'string' && error.message.toLowerCase().includes('network'));
+
+      if (isOffline && typeof onQueued === 'function') {
+        try {
+          const queueResult = await onQueued({ payload, values });
+          if (queueResult?.queued) {
+            reset();
+            if (typeof onClose === 'function') {
+              onClose();
+            }
+            return;
+          }
+        } catch (queueError) {
+          console.warn('Failed to queue work order for background sync.', queueError);
+        }
+      }
+
       const payloadError = error?.data?.error ?? {
         message: error?.message || 'Unable to create work order',
       };

--- a/frontend/src/lib/backgroundSync.js
+++ b/frontend/src/lib/backgroundSync.js
@@ -1,0 +1,81 @@
+import { API_BASE, getToken } from './api';
+
+const DEFAULT_SYNC_TAG = 'workpro-mutation-sync';
+
+function hasServiceWorker() {
+  return typeof window !== 'undefined' && 'serviceWorker' in navigator;
+}
+
+function resolveUrl(endpoint) {
+  if (!endpoint) {
+    return API_BASE;
+  }
+
+  if (/^https?:\/\//i.test(endpoint)) {
+    return endpoint;
+  }
+
+  const normalizedEndpoint = endpoint.startsWith('/') ? endpoint : `/${endpoint}`;
+  return `${API_BASE}${normalizedEndpoint}`;
+}
+
+export async function queueMutation({
+  endpoint,
+  method = 'POST',
+  body,
+  entity,
+  clientId,
+  tag = DEFAULT_SYNC_TAG,
+}) {
+  if (!hasServiceWorker()) {
+    return { queued: false, reason: 'service-worker-unavailable' };
+  }
+
+  try {
+    const registration = await navigator.serviceWorker.ready;
+
+    if (!registration) {
+      return { queued: false, reason: 'registration-unavailable' };
+    }
+
+    const sync = registration.sync;
+    if (!sync || typeof sync.register !== 'function') {
+      return { queued: false, reason: 'background-sync-unsupported' };
+    }
+
+    const worker = registration.active || registration.waiting || registration.installing;
+    if (!worker) {
+      return { queued: false, reason: 'worker-unavailable' };
+    }
+
+    const headers = { 'Content-Type': 'application/json' };
+    const token = getToken();
+    if (token) {
+      headers.Authorization = `Bearer ${token}`;
+    }
+
+    const payload = {
+      clientId,
+      endpoint: resolveUrl(endpoint),
+      method,
+      body,
+      headers,
+      entity,
+      tag,
+    };
+
+    worker.postMessage({
+      type: 'queue-mutation',
+      payload,
+    });
+
+    await sync.register(tag);
+
+    return { queued: true };
+  } catch (error) {
+    console.warn('Failed to queue mutation for background sync.', error);
+    return { queued: false, error };
+  }
+}
+
+export { DEFAULT_SYNC_TAG };

--- a/frontend/src/lib/offline-cache.js
+++ b/frontend/src/lib/offline-cache.js
@@ -1,0 +1,90 @@
+const CACHE_PREFIX = 'work-order-cache:';
+
+function hasLocalStorage() {
+  try {
+    return typeof window !== 'undefined' && !!window.localStorage;
+  } catch (error) {
+    return false;
+  }
+}
+
+function normalizeFilters(filters) {
+  if (!filters || typeof filters !== 'object') {
+    return {};
+  }
+
+  return Object.keys(filters)
+    .sort()
+    .reduce((acc, key) => {
+      const value = filters[key];
+      acc[key] = value ?? '';
+      return acc;
+    }, {});
+}
+
+function encodeHash(value) {
+  const json = JSON.stringify(value);
+
+  if (typeof window !== 'undefined' && typeof window.btoa === 'function') {
+    return window.btoa(json);
+  }
+
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(json, 'utf-8').toString('base64');
+  }
+
+  return json;
+}
+
+export function getFilterHash(filters) {
+  const normalized = normalizeFilters(filters);
+  return encodeHash(normalized);
+}
+
+function getCacheKey(hash) {
+  return `${CACHE_PREFIX}${hash}`;
+}
+
+export function saveListCache(filters, payload) {
+  if (!hasLocalStorage()) {
+    return;
+  }
+
+  try {
+    const hash = getFilterHash(filters);
+    const key = getCacheKey(hash);
+    const record = {
+      data: payload,
+      cachedAt: Date.now(),
+    };
+    window.localStorage.setItem(key, JSON.stringify(record));
+  } catch (error) {
+    console.warn('Unable to persist work order cache entry.', error);
+  }
+}
+
+export function readListCache(filters) {
+  if (!hasLocalStorage()) {
+    return null;
+  }
+
+  try {
+    const hash = getFilterHash(filters);
+    const key = getCacheKey(hash);
+    const raw = window.localStorage.getItem(key);
+
+    if (!raw) {
+      return null;
+    }
+
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && 'data' in parsed) {
+      return parsed;
+    }
+
+    return null;
+  } catch (error) {
+    console.warn('Unable to read work order cache entry.', error);
+    return null;
+  }
+}

--- a/frontend/src/pages/__tests__/WorkOrders.offline.test.jsx
+++ b/frontend/src/pages/__tests__/WorkOrders.offline.test.jsx
@@ -1,0 +1,259 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const toastHandles = [];
+const toastMock = vi.fn(() => {
+  const handle = { dismiss: vi.fn() };
+  toastHandles.push(handle);
+  return handle;
+});
+
+let queueMutationSpy;
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: toastMock, dismiss: vi.fn() }),
+}));
+
+vi.mock('@/lib/api', () => {
+  const apiMock = {
+    get: vi.fn(),
+    post: vi.fn(),
+    defaults: { baseURL: 'http://localhost/api' },
+  };
+
+  return {
+    api: apiMock,
+    API_BASE: 'http://localhost/api',
+    getToken: vi.fn(() => 'test-token'),
+  };
+});
+
+import { WorkOrders } from '../WorkOrders';
+import { api } from '@/lib/api';
+import * as backgroundSyncModule from '@/lib/backgroundSync';
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+}
+
+function renderWorkOrders(queryClient) {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <WorkOrders />
+    </QueryClientProvider>,
+  );
+}
+
+describe('WorkOrders offline behaviour', () => {
+  let consoleErrorSpy;
+
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    toastHandles.length = 0;
+    toastMock.mockClear();
+    const storage = (() => {
+      let store = new Map();
+      return {
+        getItem: (key) => (store.has(key) ? store.get(key) : null),
+        setItem: (key, value) => {
+          store.set(key, String(value));
+        },
+        removeItem: (key) => {
+          store.delete(key);
+        },
+        clear: () => {
+          store.clear();
+        },
+        key: (index) => Array.from(store.keys())[index] ?? null,
+        get length() {
+          return store.size;
+        },
+      };
+    })();
+
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: storage,
+    });
+
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: storage,
+    });
+
+    localStorage.clear();
+    Object.defineProperty(window.navigator, 'onLine', {
+      configurable: true,
+      get: () => true,
+    });
+    if (Object.prototype.hasOwnProperty.call(window.navigator, 'serviceWorker')) {
+      delete window.navigator.serviceWorker;
+    }
+    api.get.mockReset();
+    api.post.mockReset();
+    queueMutationSpy?.mockRestore();
+    queueMutationSpy = undefined;
+  });
+
+  afterEach(() => {
+    consoleErrorSpy?.mockRestore();
+    queueMutationSpy?.mockRestore();
+    queueMutationSpy = undefined;
+  });
+
+  it('hydrates from cache when offline', async () => {
+    const queryClient = createQueryClient();
+    const workOrders = [
+      {
+        id: '1',
+        title: 'Network Work Order',
+        status: 'requested',
+        priority: 'medium',
+        assigneeNames: [],
+        createdAt: new Date().toISOString(),
+      },
+    ];
+
+    api.get.mockResolvedValueOnce({ data: workOrders });
+
+    const initialRender = renderWorkOrders(queryClient);
+
+    await screen.findByText('Network Work Order', undefined, { timeout: 5000 });
+
+    expect(localStorage.length).toBeGreaterThan(0);
+    expect(api.get).toHaveBeenCalledTimes(1);
+
+    initialRender.unmount();
+
+    Object.defineProperty(window.navigator, 'onLine', {
+      configurable: true,
+      get: () => false,
+    });
+
+    api.get.mockRejectedValueOnce(Object.assign(new Error('Network Error'), { code: 'ERR_NETWORK' }));
+
+    const secondClient = createQueryClient();
+    renderWorkOrders(secondClient);
+
+    await screen.findByText('Network Work Order', undefined, { timeout: 5000 });
+    await screen.findByText(/Offline mode/, undefined, { timeout: 5000 });
+  }, 10000);
+
+  it('queues work order mutations when offline and clears toast after sync', async () => {
+    const queryClient = createQueryClient();
+
+    const registration = {
+      active: { postMessage: vi.fn() },
+      sync: { register: vi.fn().mockResolvedValue(undefined) },
+    };
+
+    const listeners = [];
+
+    Object.defineProperty(window.navigator, 'serviceWorker', {
+      configurable: true,
+      value: {
+        ready: Promise.resolve(registration),
+        addEventListener: vi.fn((event, handler) => {
+          if (event === 'message') {
+            listeners.push(handler);
+          }
+        }),
+        removeEventListener: vi.fn((event, handler) => {
+          if (event === 'message') {
+            const index = listeners.indexOf(handler);
+            if (index >= 0) {
+              listeners.splice(index, 1);
+            }
+          }
+        }),
+      },
+    });
+
+    const { DEFAULT_SYNC_TAG } = backgroundSyncModule;
+
+    queueMutationSpy = vi
+      .spyOn(backgroundSyncModule, 'queueMutation')
+      .mockImplementation(async ({ endpoint, method = 'POST', body, entity, clientId, tag }) => {
+        const effectiveTag = tag ?? DEFAULT_SYNC_TAG;
+        registration.active.postMessage({
+          type: 'queue-mutation',
+          payload: {
+            clientId,
+            endpoint,
+            method,
+            body,
+            entity,
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: 'Bearer test-token',
+            },
+            tag: effectiveTag,
+          },
+        });
+
+        await registration.sync.register(effectiveTag);
+        return { queued: true };
+      });
+
+    api.get.mockResolvedValue({ data: [] });
+    api.post.mockRejectedValueOnce(Object.assign(new Error('Network Error'), { code: 'ERR_NETWORK' }));
+
+    renderWorkOrders(queryClient);
+    await screen.findByText('No work orders found', undefined, { timeout: 5000 });
+
+    Object.defineProperty(window.navigator, 'onLine', {
+      configurable: true,
+      get: () => false,
+    });
+
+    const [newWorkOrderButton] = screen.getAllByRole('button', { name: /New Work Order/i });
+    await userEvent.click(newWorkOrderButton);
+
+    await screen.findByRole('heading', { name: 'Create Work Order' }, { timeout: 5000 });
+
+    const titleInput = await screen.findByPlaceholderText('Work order title');
+    await userEvent.clear(titleInput);
+    await userEvent.type(titleInput, 'Queued order');
+
+    await userEvent.click(screen.getByRole('button', { name: /Create Work Order/i }));
+
+    await waitFor(() => expect(api.post).toHaveBeenCalledTimes(1));
+    expect(registration.sync.register).toHaveBeenCalledWith('workpro-mutation-sync');
+    expect(toastMock).toHaveBeenCalledWith({
+      title: 'Work order queued',
+      description: 'It will sync automatically once you are back online.',
+    });
+
+    const queuedPayload = registration.active.postMessage.mock.calls[0][0];
+    expect(queuedPayload.type).toBe('queue-mutation');
+    const clientId = queuedPayload.payload.clientId;
+    expect(clientId).toBeTruthy();
+
+    await waitFor(() => expect(screen.getByText('Pending sync')).toBeInTheDocument());
+
+    Object.defineProperty(window.navigator, 'onLine', {
+      configurable: true,
+      get: () => true,
+    });
+
+    act(() => {
+      listeners.forEach((listener) =>
+        listener({ data: { type: 'mutation-synced', payload: { clientId } } }),
+      );
+    });
+
+    await waitFor(() => expect(api.get).toHaveBeenCalledTimes(2));
+
+    const lastToast = toastHandles[toastHandles.length - 1];
+    expect(lastToast?.dismiss).toHaveBeenCalled();
+    expect(screen.queryByText('Pending sync')).not.toBeInTheDocument();
+  }, 15000);
+});

--- a/frontend/src/serviceWorker.js
+++ b/frontend/src/serviceWorker.js
@@ -1,0 +1,13 @@
+export async function registerServiceWorker() {
+  if (typeof window === 'undefined' || !('serviceWorker' in navigator)) {
+    return null;
+  }
+
+  try {
+    const registration = await navigator.serviceWorker.register('/service-worker.js');
+    return registration;
+  } catch (error) {
+    console.warn('Service worker registration failed.', error);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- cache work order queries in localStorage and hydrate the list when offline, including an offline banner and pending sync badges
- enqueue failed work-order mutations through a service worker background sync helper and surface queued state in the UI
- register the service worker and add integration coverage for offline hydration and queued submissions

## Testing
- `npm test -- --run src/pages/__tests__/WorkOrders.offline.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68e26b08a3cc8323b87ceb8f21486ec5