### PR TITLE
Fix default sort destructuring in assets page

### DIFF
--- a/src/pages/Assets.tsx
+++ b/src/pages/Assets.tsx
@@ -329,7 +329,7 @@ function HierarchyBreadcrumb({ site, area, line, onNavigate }: HierarchyBreadcru
 
 type SortState = { key: string; direction: 'asc' | 'desc' };
 
-const [DEFAULT_SORT_KEY, DEFAULT_SORT_DIRECTION] = DEFAULT_SORT_KEY.split(':') as [string, string];
+const [DEFAULT_SORT_KEY, DEFAULT_SORT_DIRECTION] = DEFAULT_SORT.split(':') as [string, string];
 const DEFAULT_SORT_DIRECTION_NORMALIZED: 'asc' | 'desc' = DEFAULT_SORT_DIRECTION === 'asc' ? 'asc' : 'desc';
 
 function parseSortParam(sortValue: string | null | undefined): SortState {


### PR DESCRIPTION
## Summary
- ensure the assets page derives the default sort key and direction from the DEFAULT_SORT constant

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2ad4cfc5c83238a67ea9b1b9a3814